### PR TITLE
Fix that ConvertError crash and has incorrect value.

### DIFF
--- a/bool.go
+++ b/bool.go
@@ -24,17 +24,7 @@ func (c *ValueConverter) Bool() *BoolConverter {
 	}
 
 	if err != nil {
-		var srcType reflect.Type
-		if reflect.ValueOf(c.value).IsValid() {
-			srcType = reflect.ValueOf(c.value).Type()
-		}
-		err = &ConvertError{
-			Field:   c.field,
-			SrcType: srcType,
-			DstType: reflect.ValueOf((*bool)(nil)).Type().Elem(),
-			Value:   c.value,
-			Err:     err,
-		}
+		err = c.wrapConvertError(c.value, reflect.ValueOf((*bool)(nil)).Type().Elem(), err)
 	}
 	return &BoolConverter{converter: c.converter, value: value, err: err}
 }
@@ -71,9 +61,7 @@ func (c *BoolConverter) Convert(out interface{}) error {
 
 func (c *BoolConverter) convert(outV reflect.Value) error {
 	if c.err != nil {
-		err := *(c.err.(*ConvertError))
-		err.DstType = outV.Type()
-		return &err
+		return c.wrapConvertError(c.value, outV.Type(), c.err)
 	}
 	if c.isNil {
 		return nil

--- a/error.go
+++ b/error.go
@@ -32,8 +32,16 @@ func (e *ConvertError) Unwrap() error {
 }
 
 func (e *ConvertError) Error() string {
+	srcTypeString, dstTypeString := "nil", "nil"
+	if e.SrcType != nil {
+		srcTypeString = e.SrcType.String()
+	}
+	if e.DstType != nil {
+		dstTypeString = e.DstType.String()
+	}
+
 	return fmt.Sprintf(
 		"Failed to convert from %s to %s: fields=%s, value=%#v, error=%s",
-		e.SrcType.String(), e.DstType.String(), e.Field, e.Value, e.Err.Error(),
+		srcTypeString, dstTypeString, e.Field, e.Value, e.Err.Error(),
 	)
 }

--- a/map.go
+++ b/map.go
@@ -67,17 +67,7 @@ func (c *ValueConverter) mapWithDepth(depth uint) *MapConverter {
 	}
 
 	if err != nil {
-		var srcType reflect.Type
-		if reflect.ValueOf(c.value).IsValid() {
-			srcType = reflect.ValueOf(c.value).Type()
-		}
-		err = &ConvertError{
-			Field:   c.field,
-			SrcType: srcType,
-			DstType: reflect.ValueOf(value).Type(),
-			Value:   c.value,
-			Err:     err,
-		}
+		err = c.wrapConvertError(c.value, reflect.ValueOf(value).Type(), err)
 	}
 
 	if c.isNil {
@@ -141,17 +131,7 @@ func (c *ValueConverter) jsonMapWithDepth(depth uint) *JSONMapConverter {
 	}
 
 	if err != nil {
-		var srcType reflect.Type
-		if reflect.ValueOf(c.value).IsValid() {
-			srcType = reflect.ValueOf(c.value).Type()
-		}
-		err = &ConvertError{
-			Field:   c.field,
-			SrcType: srcType,
-			DstType: reflect.ValueOf(value).Type(),
-			Value:   c.value,
-			Err:     err,
-		}
+		err = c.wrapConvertError(c.value, reflect.ValueOf(value).Type(), err)
 	}
 
 	if c.isNil {
@@ -179,9 +159,7 @@ func (c *MapConverter) Convert(out interface{}) error {
 
 func (c *MapConverter) convert(outV reflect.Value) error {
 	if c.err != nil {
-		err := *(c.err.(*ConvertError))
-		err.DstType = outV.Type()
-		return &err
+		return c.wrapConvertError(c.value, outV.Type(), c.err)
 	}
 	if c.isNil {
 		return nil
@@ -246,7 +224,7 @@ func (c *MapConverter) convert(outV reflect.Value) error {
 			}
 		}
 	default:
-		return ErrUnsupportedType
+		return c.wrapConvertError(c.value, outV.Type(), ErrUnsupportedType)
 	}
 	return nil
 }

--- a/string.go
+++ b/string.go
@@ -47,17 +47,7 @@ func (c *ValueConverter) String() *StringConverter {
 	}
 
 	if err != nil {
-		var srcType reflect.Type
-		if reflect.ValueOf(c.value).IsValid() {
-			srcType = reflect.ValueOf(c.value).Type()
-		}
-		err = &ConvertError{
-			Field:   c.field,
-			SrcType: srcType,
-			DstType: reflect.ValueOf((*string)(nil)).Type().Elem(),
-			Value:   c.value,
-			Err:     err,
-		}
+		err = c.wrapConvertError(c.value, reflect.ValueOf((*string)(nil)).Type().Elem(), err)
 	}
 	return &StringConverter{converter: c.converter, value: value, err: err}
 }
@@ -94,9 +84,7 @@ func (c *StringConverter) Convert(out interface{}) error {
 
 func (c *StringConverter) convert(outV reflect.Value) error {
 	if c.err != nil {
-		err := *(c.err.(*ConvertError))
-		err.DstType = outV.Type()
-		return &err
+		return c.wrapConvertError(c.value, outV.Type(), c.err)
 	}
 	if c.isNil {
 		return nil

--- a/tests/bool_test.go
+++ b/tests/bool_test.go
@@ -10,7 +10,7 @@ import (
 func TestBoolConverter_Ptr(t *testing.T) {
 	ptr, err := henge.New(nil).Bool().Ptr().Result()
 	assert.Nil(t, ptr)
-	assert.Error(t, err)
+	assert.EqualError(t, err, "Failed to convert from nil to bool: fields=, value=<nil>, error=invalid value")
 
 	ptr, err = henge.New("aaaa").Bool().Ptr().Result()
 	if assert.NotNil(t, ptr) {

--- a/tests/float_test.go
+++ b/tests/float_test.go
@@ -10,7 +10,7 @@ import (
 func TestFloatConverter_Ptr(t *testing.T) {
 	ptr, err := henge.New(struct{}{}).Float().Ptr().Result()
 	assert.Nil(t, ptr)
-	assert.Error(t, err)
+	assert.EqualError(t, err, "Failed to convert from struct {} to float64: fields=, value=struct {}{}, error=unsupported type")
 
 	ptr, err = henge.New("24.5").Float().Ptr().Result()
 	if assert.NotNil(t, ptr) {
@@ -25,5 +25,5 @@ func TestFloatConverter_Ptr(t *testing.T) {
 
 	ptr, err = henge.New((*struct{})(nil)).Float().Ptr().Result()
 	assert.Nil(t, ptr)
-	assert.Error(t, err)
+	assert.EqualError(t, err, "Failed to convert from *struct {} to float64: fields=, value=(*struct {})(nil), error=unsupported type")
 }

--- a/tests/henge_test.go
+++ b/tests/henge_test.go
@@ -69,10 +69,10 @@ func TestValueConverter_Model(t *testing.T) {
 
 	// Case. Conversion fails
 	v, err = henge.New(In{X: "125"}).Model("").Result()
-	assert.Error(t, err)
+	assert.EqualError(t, err, "Failed to convert from tests.In to string: fields=, value=tests.In{X:\"125\"}, error=unsupported type")
 	assert.Equal(t, "", v)
 
 	v, err = henge.New(In{X: "125"}).Model((*string)(nil)).Result()
-	assert.Error(t, err)
+	assert.EqualError(t, err, "Failed to convert from tests.In to *string: fields=, value=tests.In{X:\"125\"}, error=unsupported type")
 	assert.Nil(t, v)
 }

--- a/tests/int_test.go
+++ b/tests/int_test.go
@@ -10,7 +10,7 @@ import (
 func TestIntegerConverterPtr(t *testing.T) {
 	ptr, err := henge.New(struct{}{}).Int().Ptr().Result()
 	assert.Nil(t, ptr)
-	assert.Error(t, err)
+	assert.EqualError(t, err, "Failed to convert from struct {} to int64: fields=, value=struct {}{}, error=unsupported type")
 
 	ptr, err = henge.New("24").Int().Ptr().Result()
 	if assert.NotNil(t, ptr) {
@@ -25,5 +25,5 @@ func TestIntegerConverterPtr(t *testing.T) {
 
 	ptr, err = henge.New((*struct{})(nil)).Int().Ptr().Result()
 	assert.Nil(t, ptr)
-	assert.Error(t, err)
+	assert.EqualError(t, err, "Failed to convert from *struct {} to int64: fields=, value=(*struct {})(nil), error=unsupported type")
 }

--- a/tests/map_test.go
+++ b/tests/map_test.go
@@ -44,7 +44,7 @@ func TestMapConverter_Nil(t *testing.T) {
 	assert.Nil(t, m)
 
 	m, err = henge.New((*int)(nil)).Map().Result()
-	assert.Error(t, err)
+	assert.EqualError(t, err, "Failed to convert from *int to map[interface {}]interface {}: fields=, value=(*int)(nil), error=unsupported type")
 	assert.Nil(t, m)
 }
 

--- a/tests/slice_test.go
+++ b/tests/slice_test.go
@@ -13,7 +13,7 @@ func TestSliceConverter_Nil(t *testing.T) {
 	assert.Nil(t, s)
 
 	s, err = henge.New((*int)(nil)).Slice().Result()
-	assert.Error(t, err)
+	assert.EqualError(t, err, "Failed to convert from *int to []interface {}: fields=, value=(*int)(nil), error=unsupported type")
 	assert.Nil(t, s)
 }
 

--- a/tests/string_test.go
+++ b/tests/string_test.go
@@ -22,7 +22,7 @@ func TestStringConverter_Convert(t *testing.T) {
 func TestStringConverter_Ptr(t *testing.T) {
 	ptr, err := henge.New(struct{}{}).String().Ptr().Result()
 	assert.Nil(t, ptr)
-	assert.Error(t, err)
+	assert.EqualError(t, err, "Failed to convert from struct {} to string: fields=, value=struct {}{}, error=unsupported type")
 
 	ptr, err = henge.New(1).String().Ptr().Result()
 	if assert.NotNil(t, ptr) {
@@ -37,5 +37,5 @@ func TestStringConverter_Ptr(t *testing.T) {
 
 	ptr, err = henge.New((*struct{})(nil)).String().Ptr().Result()
 	assert.Nil(t, ptr)
-	assert.Error(t, err)
+	assert.EqualError(t, err, "Failed to convert from *struct {} to string: fields=, value=(*struct {})(nil), error=unsupported type")
 }

--- a/tests/struct_test.go
+++ b/tests/struct_test.go
@@ -148,7 +148,11 @@ func TestStructConverter_Nil(t *testing.T) {
 	assert.NoError(t, henge.New((*struct{})(nil)).Struct().Convert(&out))
 	assert.Nil(t, out)
 
-	assert.Error(t, henge.New((*int)(nil)).Struct().Convert(&out))
+	assert.EqualError(
+		t,
+		henge.New((*int)(nil)).Struct().Convert(&out),
+		"Failed to convert from *int to *struct {}: fields=, value=(*int)(nil), error=unsupported type",
+	)
 	assert.Nil(t, out)
 }
 
@@ -191,9 +195,17 @@ func TestStructConverter_Callbacks(t *testing.T) {
 	assert.Equal(t, user.Age, out1.Age)
 
 	out1 = BeforeCallbackT{}
-	assert.Error(t, henge.New(&user).Struct().Convert(&out1))
+	assert.EqualError(
+		t,
+		henge.New(&user).Struct().Convert(&out1),
+		"Failed to convert from *tests.User to tests.BeforeCallbackT: fields=, value=&tests.User{Name:\"Alice\", Age:25}, error=failed",
+	)
 	out1 = BeforeCallbackT{}
-	assert.Error(t, henge.New(struct{ Name string }{"Bob"}).Convert(&out1))
+	assert.EqualError(
+		t,
+		henge.New(struct{ Name string }{"Bob"}).Convert(&out1),
+		"Failed to convert from struct { Name string } to tests.BeforeCallbackT: fields=, value=struct { Name string }{Name:\"Bob\"}, error=failed",
+	)
 
 	// NOTE: AfterCallbackT converts only from User{} and returns an error otherwise.
 	out2 := AfterCallbackT{}
@@ -204,9 +216,17 @@ func TestStructConverter_Callbacks(t *testing.T) {
 	assert.Equal(t, 48, out2.Age)
 
 	out2 = AfterCallbackT{}
-	assert.Error(t, henge.New(&user).Struct().Convert(&out2))
+	assert.EqualError(
+		t,
+		henge.New(&user).Struct().Convert(&out2),
+		"Failed to convert from *tests.User to tests.AfterCallbackT: fields=, value=&tests.User{Name:\"Alice\", Age:25}, error=failed",
+	)
 	out2 = AfterCallbackT{}
-	assert.Error(t, henge.New(struct{ Name string }{"Carol"}).Convert(&out2))
+	assert.EqualError(
+		t,
+		henge.New(struct{ Name string }{"Carol"}).Convert(&out2),
+		"Failed to convert from struct { Name string } to tests.AfterCallbackT: fields=, value=struct { Name string }{Name:\"Carol\"}, error=failed",
+	)
 }
 
 func TestStructConverter_Callbacks2(t *testing.T) {
@@ -230,11 +250,19 @@ func TestStructConverter_Callbacks2(t *testing.T) {
 
 	// NOTE: In the case of User{}, no error occurs, but in the case of *User{}, an error occurs.
 	outP := OutP{}
-	assert.Error(t, henge.New(InP{User: &user}).Convert(&outP))
+	assert.EqualError(
+		t,
+		henge.New(InP{User: &user}).Convert(&outP),
+		"Failed to convert from *tests.User to *tests.BeforeCallbackT: fields=.User, value=&tests.User{Name:\"Alice\", Age:25}, error=failed",
+	)
 	assert.NoError(t, henge.New(InV{User: user}).Convert(&outP))
 
 	outV := OutV{}
-	assert.Error(t, henge.New(InP{User: &user}).Convert(&outV))
+	assert.EqualError(
+		t,
+		henge.New(InP{User: &user}).Convert(&outV),
+		"Failed to convert from *tests.User to tests.BeforeCallbackT: fields=.User, value=&tests.User{Name:\"Alice\", Age:25}, error=failed",
+	)
 	assert.NoError(t, henge.New(InV{User: user}).Convert(&outV))
 }
 

--- a/tests/uint_test.go
+++ b/tests/uint_test.go
@@ -22,7 +22,7 @@ func TestUnsignedIntegerConverter_Convert(t *testing.T) {
 func TestUnsignedIntegerConverter_Ptr(t *testing.T) {
 	ptr, err := henge.New(struct{}{}).Uint().Ptr().Result()
 	assert.Nil(t, ptr)
-	assert.Error(t, err)
+	assert.EqualError(t, err, "Failed to convert from struct {} to uint64: fields=, value=struct {}{}, error=unsupported type")
 
 	ptr, err = henge.New(124).Uint().Ptr().Result()
 	if assert.NotNil(t, ptr) {
@@ -37,5 +37,5 @@ func TestUnsignedIntegerConverter_Ptr(t *testing.T) {
 
 	ptr, err = henge.New((*struct{})(nil)).Uint().Ptr().Result()
 	assert.Nil(t, ptr)
-	assert.Error(t, err)
+	assert.EqualError(t, err, "Failed to convert from *struct {} to uint64: fields=, value=(*struct {})(nil), error=unsupported type")
 }


### PR DESCRIPTION
- Fix that incorrect value stored in ConvertError, when the input value is nil.
- Fix that crash when executing ConvertError.Error() created when henge.New(nil) is executed.