### PR TITLE
Enhanced map conversion. (v2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ When using Henge, it easy to create pointer types while preserving the benefits 
 To install it, run:
 
 ```
-go get -u github.com/soranoba/henge
+go get -u github.com/soranoba/henge/v2
 ```
 
 ## Usage
@@ -50,7 +50,7 @@ go get -u github.com/soranoba/henge
 import (
 	"fmt"
 
-	"github.com/soranoba/henge"
+	"github.com/soranoba/henge/v2"
 )
 
 func main() {
@@ -79,7 +79,7 @@ func main() {
 import (
 	"fmt"
 
-	"github.com/soranoba/henge"
+	"github.com/soranoba/henge/v2"
 )
 
 func main() {

--- a/bool.go
+++ b/bool.go
@@ -4,6 +4,26 @@ import (
 	"reflect"
 )
 
+type (
+	// BoolConverter is a converter that converts a bool type to another type.
+	BoolConverter struct {
+		*baseConverter
+		value bool
+		err   error
+	}
+
+	// BoolPtrConverter is a converter that converts a pointer of bool type to another type.
+	BoolPtrConverter struct {
+		*baseConverter
+		value *bool
+		err   error
+	}
+)
+
+// --------------------------------------------------------------------- //
+// ValueConverter
+// --------------------------------------------------------------------- //
+
 // Bool converts the input to bool type.
 func (c *ValueConverter) Bool() *BoolConverter {
 	var (
@@ -34,12 +54,9 @@ func (c *ValueConverter) BoolPtr() *BoolPtrConverter {
 	return c.Bool().Ptr()
 }
 
-// BoolConverter is a converter that converts a bool type to another type.
-type BoolConverter struct {
-	*baseConverter
-	value bool
-	err   error
-}
+// --------------------------------------------------------------------- //
+// BoolConverter
+// --------------------------------------------------------------------- //
 
 // Ptr converts the input to ptr type.
 func (c *BoolConverter) Ptr() *BoolPtrConverter {
@@ -98,12 +115,9 @@ func (c *BoolConverter) Error() error {
 	return c.err
 }
 
-// BoolPtrConverter is a converter that converts a pointer of bool type to another type.
-type BoolPtrConverter struct {
-	*baseConverter
-	value *bool
-	err   error
-}
+// --------------------------------------------------------------------- //
+// BoolPtrConverter
+// --------------------------------------------------------------------- //
 
 // Result returns the conversion result and error.
 func (c *BoolPtrConverter) Result() (*bool, error) {

--- a/bool.go
+++ b/bool.go
@@ -26,7 +26,7 @@ func (c *ValueConverter) Bool() *BoolConverter {
 	if err != nil {
 		err = c.wrapConvertError(c.value, reflect.ValueOf((*bool)(nil)).Type().Elem(), err)
 	}
-	return &BoolConverter{converter: c.converter, value: value, err: err}
+	return &BoolConverter{baseConverter: c.baseConverter, value: value, err: err}
 }
 
 // BoolPtr converts the input to pointer of bool type.
@@ -36,7 +36,7 @@ func (c *ValueConverter) BoolPtr() *BoolPtrConverter {
 
 // BoolConverter is a converter that converts a bool type to another type.
 type BoolConverter struct {
-	converter
+	baseConverter
 	value bool
 	err   error
 }
@@ -44,9 +44,9 @@ type BoolConverter struct {
 // Ptr converts the input to ptr type.
 func (c *BoolConverter) Ptr() *BoolPtrConverter {
 	if c.err != nil || c.isNil {
-		return &BoolPtrConverter{converter: c.converter, value: nil, err: c.err}
+		return &BoolPtrConverter{baseConverter: c.baseConverter, value: nil, err: c.err}
 	}
-	return &BoolPtrConverter{converter: c.converter, value: &c.value, err: c.err}
+	return &BoolPtrConverter{baseConverter: c.baseConverter, value: &c.value, err: c.err}
 }
 
 // Convert converts the input to the out type and assigns it.
@@ -88,6 +88,11 @@ func (c *BoolConverter) Value() bool {
 	return c.value
 }
 
+// Interface returns the conversion result of interface type.
+func (c *BoolConverter) Interface() interface{} {
+	return c.value
+}
+
 // Error returns an error if the conversion fails
 func (c *BoolConverter) Error() error {
 	return c.err
@@ -95,7 +100,7 @@ func (c *BoolConverter) Error() error {
 
 // BoolPtrConverter is a converter that converts a pointer of bool type to another type.
 type BoolPtrConverter struct {
-	converter
+	baseConverter
 	value *bool
 	err   error
 }
@@ -107,6 +112,11 @@ func (c *BoolPtrConverter) Result() (*bool, error) {
 
 // Value returns the conversion result.
 func (c *BoolPtrConverter) Value() *bool {
+	return c.value
+}
+
+// Interface returns the conversion result of interface type.
+func (c *BoolPtrConverter) Interface() interface{} {
 	return c.value
 }
 

--- a/bool.go
+++ b/bool.go
@@ -36,7 +36,7 @@ func (c *ValueConverter) BoolPtr() *BoolPtrConverter {
 
 // BoolConverter is a converter that converts a bool type to another type.
 type BoolConverter struct {
-	baseConverter
+	*baseConverter
 	value bool
 	err   error
 }
@@ -100,7 +100,7 @@ func (c *BoolConverter) Error() error {
 
 // BoolPtrConverter is a converter that converts a pointer of bool type to another type.
 type BoolPtrConverter struct {
-	baseConverter
+	*baseConverter
 	value *bool
 	err   error
 }

--- a/bool.go
+++ b/bool.go
@@ -11,7 +11,7 @@ func (c *ValueConverter) Bool() *BoolConverter {
 		err   error
 	)
 
-	inV := reflect.Indirect(reflect.ValueOf(c.value))
+	inV := reflect.Indirect(c.reflectValue)
 	if inV.IsValid() {
 		switch inV.Type().Kind() {
 		case reflect.Bool:

--- a/callbacks.go
+++ b/callbacks.go
@@ -2,10 +2,10 @@ package henge
 
 // BeforeCallback is a callback that is executed before the conversion from a struct to the struct.
 type BeforeCallback interface {
-	BeforeConvert(src interface{}, converter Converter) error
+	BeforeConvert(src interface{}, store InstanceStore) error
 }
 
 // AfterCallback is a callback that is executed after the conversion from a struct to the struct.
 type AfterCallback interface {
-	AfterConvert(src interface{}, converter Converter) error
+	AfterConvert(src interface{}, store InstanceStore) error
 }

--- a/error.go
+++ b/error.go
@@ -16,6 +16,8 @@ var (
 	ErrOverflow = errors.New("overflows")
 	// ErrNegativeNumber is an error if converting a negative number to an unsigned type.
 	ErrNegativeNumber = errors.New("negative number")
+	// ErrNotConvertible is an error, when reflect.Value.Convert needs to use but reflect.Type.ConvertibleTo returns false.
+	ErrNotConvertible = errors.New("not convertible")
 )
 
 type (

--- a/error.go
+++ b/error.go
@@ -18,14 +18,16 @@ var (
 	ErrNegativeNumber = errors.New("negative number")
 )
 
-// ConvertError is an error that shows where the error occurred during conversion.
-type ConvertError struct {
-	Field   string
-	SrcType reflect.Type
-	DstType reflect.Type
-	Value   interface{}
-	Err     error
-}
+type (
+	// ConvertError is an error that shows where the error occurred during conversion.
+	ConvertError struct {
+		Field   string
+		SrcType reflect.Type
+		DstType reflect.Type
+		Value   interface{}
+		Err     error
+	}
+)
 
 func (e *ConvertError) Unwrap() error {
 	return e.Err

--- a/float.go
+++ b/float.go
@@ -34,7 +34,7 @@ func (c *ValueConverter) Float() *FloatConverter {
 	if err != nil {
 		err = c.wrapConvertError(c.value, reflect.ValueOf((*float64)(nil)).Type().Elem(), err)
 	}
-	return &FloatConverter{converter: c.converter, value: value, err: err}
+	return &FloatConverter{baseConverter: c.baseConverter, value: value, err: err}
 }
 
 // FloatrPtr is a deprecated method.
@@ -50,7 +50,7 @@ func (c *ValueConverter) FloatPtr() *FloatPtrConverter {
 
 // FloatConverter is a converter that converts a float type to another type.
 type FloatConverter struct {
-	converter
+	baseConverter
 	value float64
 	err   error
 }
@@ -58,7 +58,7 @@ type FloatConverter struct {
 // Int converts the input to int type.
 func (c *FloatConverter) Int() *IntegerConverter {
 	if c.err != nil {
-		return &IntegerConverter{converter: c.converter, value: 0, err: c.err}
+		return &IntegerConverter{baseConverter: c.baseConverter, value: 0, err: c.err}
 	}
 	return c.new(c.value, c.field).Int()
 }
@@ -66,7 +66,7 @@ func (c *FloatConverter) Int() *IntegerConverter {
 // Uint converts the input to uint type.
 func (c *FloatConverter) Uint() *UnsignedIntegerConverter {
 	if c.err != nil {
-		return &UnsignedIntegerConverter{converter: c.converter, value: 0, err: c.err}
+		return &UnsignedIntegerConverter{baseConverter: c.baseConverter, value: 0, err: c.err}
 	}
 	return c.new(c.value, c.field).Uint()
 }
@@ -74,9 +74,9 @@ func (c *FloatConverter) Uint() *UnsignedIntegerConverter {
 // Ptr converts the input to ptr type.
 func (c *FloatConverter) Ptr() *FloatPtrConverter {
 	if c.err != nil || c.isNil {
-		return &FloatPtrConverter{converter: c.converter, value: nil, err: c.err}
+		return &FloatPtrConverter{baseConverter: c.baseConverter, value: nil, err: c.err}
 	}
-	return &FloatPtrConverter{converter: c.converter, value: &c.value, err: c.err}
+	return &FloatPtrConverter{baseConverter: c.baseConverter, value: &c.value, err: c.err}
 }
 
 // Convert converts the input to the out type and assigns it.
@@ -123,6 +123,11 @@ func (c *FloatConverter) Value() float64 {
 	return c.value
 }
 
+// Interface returns the conversion result of interface type.
+func (c *FloatConverter) Interface() interface{} {
+	return c.value
+}
+
 // Error returns an error if the conversion fails
 func (c *FloatConverter) Error() error {
 	return c.err
@@ -130,7 +135,7 @@ func (c *FloatConverter) Error() error {
 
 // FloatPtrConverter is a converter that converts a pointer of float type to another type.
 type FloatPtrConverter struct {
-	converter
+	baseConverter
 	value *float64
 	err   error
 }
@@ -142,6 +147,11 @@ func (c *FloatPtrConverter) Result() (*float64, error) {
 
 // Value returns the conversion result.
 func (c *FloatPtrConverter) Value() *float64 {
+	return c.value
+}
+
+// Interface returns the conversion result of interface type.
+func (c *FloatPtrConverter) Interface() interface{} {
 	return c.value
 }
 

--- a/float.go
+++ b/float.go
@@ -12,7 +12,7 @@ func (c *ValueConverter) Float() *FloatConverter {
 		err   error
 	)
 
-	inV := reflect.Indirect(reflect.ValueOf(c.value))
+	inV := reflect.Indirect(c.reflectValue)
 	if inV.IsValid() {
 		inT := inV.Type()
 		outT := reflect.TypeOf(value)

--- a/float.go
+++ b/float.go
@@ -37,12 +37,6 @@ func (c *ValueConverter) Float() *FloatConverter {
 	return &FloatConverter{baseConverter: c.baseConverter, value: value, err: err}
 }
 
-// FloatrPtr is a deprecated method.
-// Please use FloatPtr.
-func (c *ValueConverter) FloatrPtr() *FloatPtrConverter {
-	return c.Float().Ptr()
-}
-
 // FloatPtr converts the input to pointer of float type.
 func (c *ValueConverter) FloatPtr() *FloatPtrConverter {
 	return c.Float().Ptr()

--- a/float.go
+++ b/float.go
@@ -5,6 +5,26 @@ import (
 	"strconv"
 )
 
+type (
+	// FloatConverter is a converter that converts a float type to another type.
+	FloatConverter struct {
+		*baseConverter
+		value float64
+		err   error
+	}
+
+	// FloatPtrConverter is a converter that converts a pointer of float type to another type.
+	FloatPtrConverter struct {
+		*baseConverter
+		value *float64
+		err   error
+	}
+)
+
+// --------------------------------------------------------------------- //
+// ValueConverter
+// --------------------------------------------------------------------- //
+
 // Float converts the input to float type.
 func (c *ValueConverter) Float() *FloatConverter {
 	var (
@@ -42,12 +62,9 @@ func (c *ValueConverter) FloatPtr() *FloatPtrConverter {
 	return c.Float().Ptr()
 }
 
-// FloatConverter is a converter that converts a float type to another type.
-type FloatConverter struct {
-	*baseConverter
-	value float64
-	err   error
-}
+// --------------------------------------------------------------------- //
+// FloatConverter
+// --------------------------------------------------------------------- //
 
 // Int converts the input to int type.
 func (c *FloatConverter) Int() *IntegerConverter {
@@ -127,12 +144,9 @@ func (c *FloatConverter) Error() error {
 	return c.err
 }
 
-// FloatPtrConverter is a converter that converts a pointer of float type to another type.
-type FloatPtrConverter struct {
-	*baseConverter
-	value *float64
-	err   error
-}
+// --------------------------------------------------------------------- //
+// FloatPtrConverter
+// --------------------------------------------------------------------- //
 
 // Result returns the conversion result and error.
 func (c *FloatPtrConverter) Result() (*float64, error) {

--- a/float.go
+++ b/float.go
@@ -50,7 +50,7 @@ func (c *ValueConverter) FloatPtr() *FloatPtrConverter {
 
 // FloatConverter is a converter that converts a float type to another type.
 type FloatConverter struct {
-	baseConverter
+	*baseConverter
 	value float64
 	err   error
 }
@@ -135,7 +135,7 @@ func (c *FloatConverter) Error() error {
 
 // FloatPtrConverter is a converter that converts a pointer of float type to another type.
 type FloatPtrConverter struct {
-	baseConverter
+	*baseConverter
 	value *float64
 	err   error
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/soranoba/henge
+module github.com/soranoba/henge/v2
 
 go 1.15

--- a/henge.go
+++ b/henge.go
@@ -35,12 +35,12 @@ import (
 type (
 	// InstanceStore is an interface for Converter holds some key-value pairs.
 	InstanceStore interface {
-		// Get returns the value saved using Set.
-		Get(key string) interface{}
-		// Set saves the value on the key.
-		Set(key string, value interface{})
-		// SetValues saves multiple key-value pairs.
-		SetValues(m map[string]interface{})
+		// InstanceGet returns the value saved using Set.
+		InstanceGet(key string) interface{}
+		// InstanceSet saves the value on the key.
+		InstanceSet(key string, value interface{})
+		// InstanceSetValues saves multiple key-value pairs.
+		InstanceSetValues(m map[string]interface{})
 	}
 
 	// Converter is an interface that has common functions of all Converters.
@@ -67,18 +67,18 @@ func (c *baseConverter) new(i interface{}, fieldName string) *ValueConverter {
 	return newConverter
 }
 
-// Get returns the value saved using Set.
-func (c *baseConverter) Get(key string) interface{} {
+// InstanceGet returns the value saved using Set.
+func (c *baseConverter) InstanceGet(key string) interface{} {
 	return c.storage[key]
 }
 
-// Set saves the value on the key.
-func (c *baseConverter) Set(key string, value interface{}) {
+// InstanceSet saves the value on the key.
+func (c *baseConverter) InstanceSet(key string, value interface{}) {
 	c.storage[key] = value
 }
 
-// SetValues saves multiple key-value pairs.
-func (c *baseConverter) SetValues(m map[string]interface{}) {
+// InstanceSetValues saves multiple key-value pairs.
+func (c *baseConverter) InstanceSetValues(m map[string]interface{}) {
 	for k, v := range m {
 		c.storage[k] = v
 	}

--- a/henge.go
+++ b/henge.go
@@ -89,7 +89,7 @@ func (c *baseConverter) wrapConvertError(src interface{}, dstType reflect.Type, 
 
 // ValueConverter is a converter that converts an interface type to another type.
 type ValueConverter struct {
-	baseConverter
+	*baseConverter
 	value interface{}
 	err   error
 }
@@ -115,7 +115,7 @@ func New(i interface{}, fs ...func(*ConverterOpts)) *ValueConverter {
 	}
 
 	return &ValueConverter{
-		baseConverter: baseConverter{
+		baseConverter: &baseConverter{
 			isNil:   isNil,
 			opts:    opts,
 			storage: map[string]interface{}{},

--- a/henge.go
+++ b/henge.go
@@ -3,6 +3,25 @@
 // 変化 (Henge) means "Appearing with a different figure." in Japanese.
 // Henge as the name implies can easily convert to different types.
 //
+// Usage
+//
+// Package henge has three conversion methods.
+//
+// 1. Methods having prefix with To. (e.g. ToInt). These are syntactic sugar. It often used when it can be converted reliably.
+//
+//   henge.ToInt("1")
+//
+// 2. Starting from New and continue to other methods using method chain.
+//
+//   value, err := henge.New("1").Int().Result()
+//
+// 3. Using Convert method, it can convert to any type.
+//
+//   in := map[interface{}]interface{}{"a":1,"b":2}
+//
+//   var out map[string]interface{}
+//   henge.New(in).Convert(&out)
+//
 // Links
 //
 // Source code: https://github.com/soranoba/henge

--- a/henge.go
+++ b/henge.go
@@ -35,7 +35,7 @@ type (
 	baseConverter struct {
 		isNil   bool
 		field   string
-		opts    ConverterOpts
+		opts    *converterOpts
 		storage map[string]interface{}
 	}
 )
@@ -93,10 +93,10 @@ type ValueConverter struct {
 }
 
 // New returns a new ValueConverter
-func New(i interface{}, fs ...func(*ConverterOpts)) *ValueConverter {
+func New(i interface{}, fs ...ConverterOption) *ValueConverter {
 	opts := defaultConverterOpts()
 	for _, f := range fs {
-		f(&opts)
+		f(opts)
 	}
 
 	reflectValue := reflect.ValueOf(i)

--- a/henge.go
+++ b/henge.go
@@ -112,6 +112,8 @@ func New(i interface{}, fs ...func(*ConverterOpts)) *ValueConverter {
 		}
 	case reflect.Interface:
 		isNil = reflectValue.IsNil()
+	case reflect.Invalid:
+		isNil = true
 	}
 
 	return &ValueConverter{

--- a/henge.go
+++ b/henge.go
@@ -31,6 +31,7 @@ type (
 		Error() error
 	}
 
+	// baseConverter is a struct inherited by each Converter and has common functions.
 	baseConverter struct {
 		isNil   bool
 		field   string
@@ -47,12 +48,12 @@ func (c *baseConverter) new(i interface{}, fieldName string) *ValueConverter {
 	return newConverter
 }
 
-// Get returns the value saved using InstanceSet.
+// Get returns the value saved using Set.
 func (c *baseConverter) Get(key string) interface{} {
 	return c.storage[key]
 }
 
-// Set saves the value by specifying the key.
+// Set saves the value on the key.
 func (c *baseConverter) Set(key string, value interface{}) {
 	c.storage[key] = value
 }

--- a/henge_test.go
+++ b/henge_test.go
@@ -3,6 +3,7 @@ package henge
 import (
 	"fmt"
 	"math"
+	"time"
 )
 
 func Example_methodChain() {
@@ -263,4 +264,59 @@ func ExampleValueConverter_Model() {
 
 	// Output:
 	// henge.In{X:"125"} -> &henge.Out{X:125}
+}
+
+func ExampleValueConverter_As() {
+	var out time.Time
+	now := time.Unix(1257894000, 0)
+
+	// time.Time to time.Time
+	if err := New(now).As(&out); err != nil {
+		fmt.Println(err)
+	} else {
+		fmt.Println(out.String())
+	}
+
+	out = time.Time{}
+
+	// *time.Time to time.Time
+	if err := New(&now).As(&out); err != nil {
+		fmt.Println(err)
+	} else {
+		fmt.Println(out.String())
+	}
+
+	out = time.Time{}
+	nowP := &now
+
+	// **time.Time to time.Time
+	if err := New(&nowP).As(&out); err != nil {
+		fmt.Println(err)
+	} else {
+		fmt.Println(out.String())
+	}
+
+	var outP *time.Time
+
+	// time.Time to *time.Time
+	if err := New(now).As(&outP); err != nil {
+		fmt.Println(err)
+	} else {
+		fmt.Println(out.String())
+	}
+
+	// string to float
+	var f float64
+	if err := New("32").As(&f); err != nil {
+		fmt.Println(err)
+	} else {
+		fmt.Println(f)
+	}
+
+	// Output:
+	// 2009-11-11 08:00:00 +0900 JST
+	// 2009-11-11 08:00:00 +0900 JST
+	// 2009-11-11 08:00:00 +0900 JST
+	// 2009-11-11 08:00:00 +0900 JST
+	// Failed to convert from string to float64: fields=, value="32", error=not convertible
 }

--- a/henge_test.go
+++ b/henge_test.go
@@ -268,7 +268,7 @@ func ExampleValueConverter_Model() {
 
 func ExampleValueConverter_As() {
 	var out time.Time
-	now := time.Unix(1257894000, 0)
+	now := time.Unix(1257894000, 0).UTC()
 
 	// time.Time to time.Time
 	if err := New(now).As(&out); err != nil {
@@ -314,9 +314,9 @@ func ExampleValueConverter_As() {
 	}
 
 	// Output:
-	// 2009-11-11 08:00:00 +0900 JST
-	// 2009-11-11 08:00:00 +0900 JST
-	// 2009-11-11 08:00:00 +0900 JST
-	// 2009-11-11 08:00:00 +0900 JST
+	// 2009-11-10 23:00:00 +0000 UTC
+	// 2009-11-10 23:00:00 +0000 UTC
+	// 2009-11-10 23:00:00 +0000 UTC
+	// 2009-11-10 23:00:00 +0000 UTC
 	// Failed to convert from string to float64: fields=, value="32", error=not convertible
 }

--- a/int.go
+++ b/int.go
@@ -54,7 +54,7 @@ func (c *ValueConverter) Int() *IntegerConverter {
 	if err != nil {
 		err = c.wrapConvertError(c.value, reflect.ValueOf((*int64)(nil)).Type().Elem(), err)
 	}
-	return &IntegerConverter{converter: c.converter, value: value, err: err}
+	return &IntegerConverter{baseConverter: c.baseConverter, value: value, err: err}
 }
 
 // IntPtr converts the input to pointer of int type.
@@ -64,7 +64,7 @@ func (c *ValueConverter) IntPtr() *IntegerPtrConverter {
 
 // IntegerConverter is a converter that converts an integer type to another type.
 type IntegerConverter struct {
-	converter
+	baseConverter
 	value int64
 	err   error
 }
@@ -72,9 +72,9 @@ type IntegerConverter struct {
 // Ptr converts the input to ptr type.
 func (c *IntegerConverter) Ptr() *IntegerPtrConverter {
 	if c.err != nil || c.isNil {
-		return &IntegerPtrConverter{converter: c.converter, value: nil, err: c.err}
+		return &IntegerPtrConverter{baseConverter: c.baseConverter, value: nil, err: c.err}
 	}
-	return &IntegerPtrConverter{converter: c.converter, value: &c.value, err: nil}
+	return &IntegerPtrConverter{baseConverter: c.baseConverter, value: &c.value, err: nil}
 }
 
 // Convert converts the input to the out type and assigns it.
@@ -137,6 +137,11 @@ func (c *IntegerConverter) Value() int64 {
 	return c.value
 }
 
+// Interface returns the conversion result of interface type.
+func (c *IntegerConverter) Interface() interface{} {
+	return c.value
+}
+
 // Error returns an error if the conversion fails.
 func (c *IntegerConverter) Error() error {
 	return c.err
@@ -144,7 +149,7 @@ func (c *IntegerConverter) Error() error {
 
 // IntegerPtrConverter is a converter that converts a pointer of integer type to another type.
 type IntegerPtrConverter struct {
-	converter
+	baseConverter
 	value *int64
 	err   error
 }
@@ -156,6 +161,11 @@ func (c *IntegerPtrConverter) Result() (*int64, error) {
 
 // Value returns the conversion result.
 func (c *IntegerPtrConverter) Value() *int64 {
+	return c.value
+}
+
+// Interface returns the conversion result of interface type.
+func (c *IntegerPtrConverter) Interface() interface{} {
 	return c.value
 }
 

--- a/int.go
+++ b/int.go
@@ -64,7 +64,7 @@ func (c *ValueConverter) IntPtr() *IntegerPtrConverter {
 
 // IntegerConverter is a converter that converts an integer type to another type.
 type IntegerConverter struct {
-	baseConverter
+	*baseConverter
 	value int64
 	err   error
 }
@@ -149,7 +149,7 @@ func (c *IntegerConverter) Error() error {
 
 // IntegerPtrConverter is a converter that converts a pointer of integer type to another type.
 type IntegerPtrConverter struct {
-	baseConverter
+	*baseConverter
 	value *int64
 	err   error
 }

--- a/int.go
+++ b/int.go
@@ -13,7 +13,7 @@ func (c *ValueConverter) Int() *IntegerConverter {
 		err   error
 	)
 
-	inV := reflect.Indirect(reflect.ValueOf(c.value))
+	inV := reflect.Indirect(c.reflectValue)
 	if inV.IsValid() {
 		inT := inV.Type()
 		outT := reflect.TypeOf(value)

--- a/int.go
+++ b/int.go
@@ -6,6 +6,26 @@ import (
 	"strconv"
 )
 
+type (
+	// IntegerConverter is a converter that converts an integer type to another type.
+	IntegerConverter struct {
+		*baseConverter
+		value int64
+		err   error
+	}
+
+	// IntegerPtrConverter is a converter that converts a pointer of integer type to another type.
+	IntegerPtrConverter struct {
+		*baseConverter
+		value *int64
+		err   error
+	}
+)
+
+// --------------------------------------------------------------------- //
+// ValueConverter
+// --------------------------------------------------------------------- //
+
 // Int converts the input to int type.
 func (c *ValueConverter) Int() *IntegerConverter {
 	var (
@@ -62,12 +82,9 @@ func (c *ValueConverter) IntPtr() *IntegerPtrConverter {
 	return c.Int().Ptr()
 }
 
-// IntegerConverter is a converter that converts an integer type to another type.
-type IntegerConverter struct {
-	*baseConverter
-	value int64
-	err   error
-}
+// --------------------------------------------------------------------- //
+// IntegerConverter
+// --------------------------------------------------------------------- //
 
 // Ptr converts the input to ptr type.
 func (c *IntegerConverter) Ptr() *IntegerPtrConverter {
@@ -147,12 +164,9 @@ func (c *IntegerConverter) Error() error {
 	return c.err
 }
 
-// IntegerPtrConverter is a converter that converts a pointer of integer type to another type.
-type IntegerPtrConverter struct {
-	*baseConverter
-	value *int64
-	err   error
-}
+// --------------------------------------------------------------------- //
+// IntegerPtrConverter
+// --------------------------------------------------------------------- //
 
 // Result returns the conversion result and error.
 func (c *IntegerPtrConverter) Result() (*int64, error) {

--- a/json.go
+++ b/json.go
@@ -1,0 +1,108 @@
+package henge
+
+import "reflect"
+
+type (
+	JSONValueConverter struct {
+		Converter
+	}
+	JSONArrayConverter struct {
+		*SliceConverter
+	}
+	JSONObjectConverter struct {
+		*baseConverter
+		value map[string]interface{}
+		err   error
+	}
+)
+
+type (
+	errorOnlyConverter struct {
+		*baseConverter
+		err error
+	}
+)
+
+// JSONValue converts the input to JSON value (boolean or string or numeric or array or map)
+func (c *ValueConverter) JSONValue() *JSONValueConverter {
+	switch reflect.Indirect(c.reflectValue).Kind() {
+	case reflect.String:
+		return &JSONValueConverter{Converter: c.String()}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return &JSONValueConverter{Converter: c.Int()}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return &JSONValueConverter{Converter: c.Uint()}
+	case reflect.Float32, reflect.Float64:
+		return &JSONValueConverter{Converter: c.Float()}
+	case reflect.Bool:
+		return &JSONValueConverter{Converter: c.Bool()}
+	case reflect.Map, reflect.Struct:
+		return &JSONValueConverter{Converter: c.JSONObject()}
+	case reflect.Array, reflect.Slice:
+		return &JSONValueConverter{Converter: c.JSONArray()}
+	default:
+		return &JSONValueConverter{
+			Converter: &errorOnlyConverter{
+				err: c.wrapConvertError(c.value, reflect.TypeOf((*string)(nil)).Elem(), ErrUnsupportedType),
+			},
+		}
+	}
+}
+
+func (c *ValueConverter) JSONArray() *JSONArrayConverter {
+	newConv := c.new(c.value, c.field)
+	newConv.opts.sliceOpts.valueConversionFunc = func(converter *ValueConverter) Converter {
+		return converter.JSONValue()
+	}
+	return &JSONArrayConverter{SliceConverter: newConv.Slice()}
+}
+
+func (c *ValueConverter) JSONObject() *JSONObjectConverter {
+	if c.isNil {
+		return &JSONObjectConverter{baseConverter: c.baseConverter, value: nil, err: nil}
+	}
+
+	var out map[string]interface{}
+	newConv := c.new(c.value, c.field)
+	newConv.opts.mapOpts.keyType = reflect.TypeOf((*string)(nil)).Elem()
+	newConv.opts.mapOpts.keyConversionFunc = func(converter *ValueConverter) Converter {
+		return converter.String()
+	}
+	newConv.opts.mapOpts.valueConversionFunc = func(converter *ValueConverter) Converter {
+		return converter.JSONValue()
+	}
+	err := newConv.Convert(&out)
+	return &JSONObjectConverter{baseConverter: newConv.baseConverter, value: out, err: err}
+}
+
+func (c *JSONValueConverter) Result() (interface{}, error) {
+	return c.Interface(), c.Error()
+}
+
+func (c *JSONValueConverter) Value() interface{} {
+	return c.Interface()
+}
+
+func (c *JSONObjectConverter) Result() (map[string]interface{}, error) {
+	return c.value, c.err
+}
+
+func (c *JSONObjectConverter) Value() map[string]interface{} {
+	return c.value
+}
+
+func (c *JSONObjectConverter) Interface() interface{} {
+	return c.value
+}
+
+func (c *JSONObjectConverter) Error() error {
+	return c.err
+}
+
+func (c *errorOnlyConverter) Interface() interface{} {
+	return nil
+}
+
+func (c *errorOnlyConverter) Error() error {
+	return c.err
+}

--- a/json_test.go
+++ b/json_test.go
@@ -1,0 +1,144 @@
+package henge
+
+import (
+	"fmt"
+	"math"
+)
+
+func ExampleValueConverter_JSONValue() {
+	fmt.Println("int64")
+	fmt.Printf("%v -> %v\n", math.MinInt64, New(math.MinInt64).JSONValue().Value())
+	fmt.Printf("%v -> %v\n", 0, New(0).JSONValue().Value())
+	fmt.Println()
+
+	fmt.Println("uint64")
+	fmt.Printf("%v -> %v\n", uint64(math.MaxUint64), New(uint64(math.MaxUint64)).JSONValue().Value())
+	fmt.Printf("%v -> %v\n", 0, New(0).JSONValue().Value())
+	fmt.Println()
+
+	fmt.Println("float64")
+	fmt.Printf("%v -> %v\n", -1*math.MaxFloat64, New(-1*math.MaxFloat64).JSONValue().Value())
+	fmt.Printf("%v -> %v\n", 0.0, New(0.0).JSONValue().Value())
+	fmt.Println()
+
+	fmt.Println("bool")
+	fmt.Printf("%v -> %v\n", true, New(true).JSONValue().Value())
+	fmt.Printf("%v -> %v\n", false, New(false).JSONValue().Value())
+	fmt.Println()
+
+	fmt.Println("string")
+	fmt.Printf("%v -> %v\n", "aaaa", New("aaaa").JSONValue().Value())
+	fmt.Println()
+
+	fmt.Println("null")
+	fmt.Printf("%v -> %v\n", nil, New(nil).JSONValue().Value())
+	fmt.Println()
+
+	type Y struct {
+		Z string
+	}
+	type X struct {
+		Y
+	}
+	type Object struct {
+		X
+	}
+
+	fmt.Println("object")
+	fmt.Printf("%#v\n  -> %#v\n", Object{X: X{Y{Z: "z"}}}, New(Object{X: X{Y{Z: "z"}}}).JSONValue().Value())
+	fmt.Printf(
+		"%#v\n  -> %#v\n",
+		map[interface{}]interface{}{"a": Object{X: X{Y{Z: "z"}}}},
+		New(map[interface{}]interface{}{"a": Object{X: X{Y{Z: "z"}}}}).JSONValue().Value(),
+	)
+	fmt.Println()
+
+	fmt.Println("array")
+	fmt.Printf(
+		"%#v\n  -> %#v\n",
+		[]interface{}{Object{X: X{Y{Z: "z"}}}},
+		New([]interface{}{Object{X: X{Y{Z: "z"}}}}).JSONValue().Value(),
+	)
+
+	// Output:
+	// int64
+	// -9223372036854775808 -> -9223372036854775808
+	// 0 -> 0
+	//
+	// uint64
+	// 18446744073709551615 -> 18446744073709551615
+	// 0 -> 0
+	//
+	// float64
+	// -1.7976931348623157e+308 -> -1.7976931348623157e+308
+	// 0 -> 0
+	//
+	// bool
+	// true -> true
+	// false -> false
+	//
+	// string
+	// aaaa -> aaaa
+	//
+	// null
+	// <nil> -> <nil>
+	//
+	// object
+	// henge.Object{X:henge.X{Y:henge.Y{Z:"z"}}}
+	//   -> map[string]interface {}{"X":map[string]interface {}{"Y":map[string]interface {}{"Z":"z"}}}
+	// map[interface {}]interface {}{"a":henge.Object{X:henge.X{Y:henge.Y{Z:"z"}}}}
+	//   -> map[string]interface {}{"a":map[string]interface {}{"X":map[string]interface {}{"Y":map[string]interface {}{"Z":"z"}}}}
+	//
+	// array
+	// []interface {}{henge.Object{X:henge.X{Y:henge.Y{Z:"z"}}}}
+	//   -> []interface {}{map[string]interface {}{"X":map[string]interface {}{"Y":map[string]interface {}{"Z":"z"}}}}
+}
+
+func ExampleValueConverter_JSONObject() {
+	type Y struct {
+		Z string
+	}
+	type X struct {
+		Y
+	}
+	type Object struct {
+		X
+	}
+
+	value := map[interface{}]interface{}{"a": Object{X: X{Y{Z: "z"}}}}
+	fmt.Printf("%#v\n  -> %#v\n", value, New(value).JSONValue().Value())
+
+	// Output:
+	// map[interface {}]interface {}{"a":henge.Object{X:henge.X{Y:henge.Y{Z:"z"}}}}
+	//   -> map[string]interface {}{"a":map[string]interface {}{"X":map[string]interface {}{"Y":map[string]interface {}{"Z":"z"}}}}
+}
+
+func ExampleValueConverter_JSONArray() {
+	type Y struct {
+		Z string
+	}
+	type X struct {
+		Y
+	}
+	type Object struct {
+		X
+	}
+
+	value := []interface{}{
+		1,
+		true,
+		"a",
+		map[interface{}]interface{}{1: Y{Z: "z"}},
+		Object{X: X{Y{Z: "z"}}},
+	}
+	for i, v := range New(value).JSONArray().Value() {
+		fmt.Printf("[%v] %#v -> %#v\n", i, value[i], v)
+	}
+
+	// Output:
+	// [0] 1 -> 1
+	// [1] true -> true
+	// [2] "a" -> "a"
+	// [3] map[interface {}]interface {}{1:henge.Y{Z:"z"}} -> map[string]interface {}{"1":map[string]interface {}{"Z":"z"}}
+	// [4] henge.Object{X:henge.X{Y:henge.Y{Z:"z"}}} -> map[string]interface {}{"X":map[string]interface {}{"Y":map[string]interface {}{"Z":"z"}}}
+}

--- a/map.go
+++ b/map.go
@@ -142,7 +142,7 @@ func (c *ValueConverter) jsonMapWithDepth(depth uint) *JSONMapConverter {
 
 // MapConverter is a converter that converts a map type to another type.
 type MapConverter struct {
-	baseConverter
+	*baseConverter
 	value map[interface{}]interface{}
 	err   error
 }
@@ -251,7 +251,7 @@ func (c *MapConverter) Error() error {
 
 // JSONMapConverter is a converter that converts a json map type to another type.
 type JSONMapConverter struct {
-	baseConverter
+	*baseConverter
 	value map[string]interface{}
 	err   error
 }

--- a/map.go
+++ b/map.go
@@ -30,7 +30,7 @@ func (c *ValueConverter) mapWithDepth(depth uint) *MapConverter {
 				continue
 			}
 			strKey := New(iterK.Interface()).String().Value()
-			kConv := c.opts.keyConversionFunc(c.new(iterK.Interface(), c.field+"[]"+strKey))
+			kConv := c.opts.mapOpts.keyConversionFunc(c.new(iterK.Interface(), c.field+"[]"+strKey))
 			if err = kConv.Error(); err != nil {
 				goto End
 			}
@@ -47,7 +47,7 @@ func (c *ValueConverter) mapWithDepth(depth uint) *MapConverter {
 				}
 				fallthrough
 			default:
-				vConv := c.opts.valueConversionFunc(iterK.Interface(), c.new(iterV.Interface(), c.field+"."+strKey))
+				vConv := c.opts.mapOpts.valueConversionFunc(c.new(iterV.Interface(), c.field+"."+strKey))
 				if err = vConv.Error(); err != nil {
 					goto End
 				}
@@ -84,7 +84,7 @@ func (c *ValueConverter) mapWithDepth(depth uint) *MapConverter {
 				}
 				fallthrough
 			default:
-				vConv := c.opts.valueConversionFunc(key, c.new(field.Interface(), c.field+"."+key))
+				vConv := c.opts.mapOpts.valueConversionFunc(c.new(field.Interface(), c.field+"."+key))
 				if err = vConv.Error(); err != nil {
 					goto End
 				}

--- a/map.go
+++ b/map.go
@@ -2,6 +2,15 @@ package henge
 
 import "reflect"
 
+type (
+	// MapConverter is a converter that converts a map type to another type.
+	MapConverter struct {
+		*baseConverter
+		value reflect.Value
+		err   error
+	}
+)
+
 // Map converts the input to map type.
 func (c *ValueConverter) Map() *MapConverter {
 	return c.mapWithDepth(0)
@@ -90,13 +99,6 @@ func (c *ValueConverter) mapWithDepth(depth uint) *MapConverter {
 	}
 
 	return &MapConverter{baseConverter: c.baseConverter, value: value, err: err}
-}
-
-// MapConverter is a converter that converts a map type to another type.
-type MapConverter struct {
-	*baseConverter
-	value reflect.Value
-	err   error
 }
 
 // Convert converts the input to the out type and assigns it.

--- a/map.go
+++ b/map.go
@@ -18,7 +18,7 @@ func (c *ValueConverter) mapWithDepth(depth uint) *MapConverter {
 		err   error
 	)
 
-	inV := reflect.Indirect(reflect.ValueOf(c.value))
+	inV := reflect.Indirect(c.reflectValue)
 	switch inV.Kind() {
 	case reflect.Map:
 		value = map[interface{}]interface{}{}
@@ -82,7 +82,7 @@ func (c *ValueConverter) jsonMapWithDepth(depth uint) *JSONMapConverter {
 		err   error
 	)
 
-	inV := reflect.Indirect(reflect.ValueOf(c.value))
+	inV := reflect.Indirect(c.reflectValue)
 	switch inV.Kind() {
 	case reflect.Map:
 		value = map[string]interface{}{}

--- a/map.go
+++ b/map.go
@@ -12,97 +12,82 @@ func (c *ValueConverter) JSONMap() *JSONMapConverter {
 	return c.jsonMapWithDepth(0)
 }
 
+func (c *ValueConverter) makeOutputMapVar() reflect.Value {
+	return reflect.New(reflect.MapOf(c.opts.mapOpts.keyType, interfaceType)).Elem()
+}
+
 func (c *ValueConverter) mapWithDepth(depth uint) *MapConverter {
 	var (
-		value map[interface{}]interface{}
+		value = c.makeOutputMapVar()
 		err   error
 	)
+
+	convAndSet := func(kVal reflect.Value, vVal reflect.Value) {
+		if !kVal.CanInterface() || !vVal.CanInterface() {
+			return
+		}
+		if !c.opts.mapOpts.filterFuns.All(kVal.Interface(), vVal.Interface()) {
+			return
+		}
+		strKey := New(kVal.Interface()).String().Value()
+		kConv := c.opts.mapOpts.keyConversionFunc(c.new(kVal.Interface(), c.field+"[]"+strKey))
+		if err = kConv.Error(); err != nil {
+			return
+		}
+
+		// NOTE: `reflect.ValueOf(nil)` cannot use at SetMapIndex.
+		//       Therefore, it uses ptr and Elem after store it on a variable once.
+		k := kConv.Interface()
+		convertedKeyVal := reflect.ValueOf(&k).Elem()
+
+		switch reflect.Indirect(reflect.ValueOf(vVal.Interface())).Kind() {
+		case reflect.Struct, reflect.Map:
+			if depth < c.opts.mapOpts.maxDepth {
+				var v interface{}
+				if v, err = c.new(vVal.Interface(), c.field+"."+strKey).mapWithDepth(depth + 1).Result(); err != nil {
+					return
+				}
+				value.SetMapIndex(convertedKeyVal, reflect.ValueOf(&v).Elem())
+				break
+			}
+			fallthrough
+		default:
+			vConv := c.opts.mapOpts.valueConversionFunc(c.new(vVal.Interface(), c.field+"."+strKey))
+			if err = vConv.Error(); err != nil {
+				return
+			}
+			v := vConv.Interface()
+			value.SetMapIndex(convertedKeyVal, reflect.ValueOf(&v).Elem())
+		}
+	}
 
 	inV := reflect.Indirect(c.reflectValue)
 	switch inV.Kind() {
 	case reflect.Map:
-		value = map[interface{}]interface{}{}
+		value = reflect.MakeMap(value.Type())
 		iter := inV.MapRange()
 		for iter.Next() {
-			iterK := iter.Key()
-			iterV := iter.Value()
-			if !c.opts.mapOpts.filterFuns.All(iterK.Interface(), iterV.Interface()) {
-				continue
-			}
-			strKey := New(iterK.Interface()).String().Value()
-			kConv := c.opts.mapOpts.keyConversionFunc(c.new(iterK.Interface(), c.field+"[]"+strKey))
-			if err = kConv.Error(); err != nil {
-				goto End
-			}
-
-			switch reflect.Indirect(reflect.ValueOf(iterV.Interface())).Kind() {
-			case reflect.Struct, reflect.Map:
-				if depth < c.opts.mapOpts.maxDepth {
-					var v interface{}
-					if v, err = c.new(iterV.Interface(), c.field+"."+strKey).mapWithDepth(depth + 1).Result(); err != nil {
-						goto End
-					}
-					value[kConv.Interface()] = v
-					break
-				}
-				fallthrough
-			default:
-				vConv := c.opts.mapOpts.valueConversionFunc(c.new(iterV.Interface(), c.field+"."+strKey))
-				if err = vConv.Error(); err != nil {
-					goto End
-				}
-				value[kConv.Interface()] = vConv.Interface()
+			convAndSet(iter.Key(), iter.Value())
+			if err != nil {
+				break
 			}
 		}
 	case reflect.Struct:
-		value = map[interface{}]interface{}{}
+		value = reflect.MakeMap(value.Type())
 		for i := 0; i < inV.NumField(); i++ {
-			field := inV.Field(i)
-			if !field.CanInterface() {
-				continue
-			}
-
-			key := inV.Type().Field(i).Name
-			if !c.opts.mapOpts.filterFuns.All(key, field.Interface()) {
-				continue
-			}
-
-			kConv := c.opts.keyConversionFunc(c.new(key, c.field+"[]"+key))
-			if err = kConv.Error(); err != nil {
-				goto End
-			}
-
-			switch reflect.Indirect(field).Kind() {
-			case reflect.Struct, reflect.Map:
-				if depth < c.opts.mapOpts.maxDepth {
-					var v interface{}
-					if v, err = c.new(field.Interface(), c.field+"."+key).mapWithDepth(depth + 1).Result(); err != nil {
-						goto End
-					}
-					value[kConv.Interface()] = v
-					break
-				}
-				fallthrough
-			default:
-				vConv := c.opts.mapOpts.valueConversionFunc(c.new(field.Interface(), c.field+"."+key))
-				if err = vConv.Error(); err != nil {
-					goto End
-				}
-				value[kConv.Interface()] = vConv.Interface()
+			convAndSet(reflect.ValueOf(inV.Type().Field(i).Name), inV.Field(i))
+			if err != nil {
+				break
 			}
 		}
 	default:
 		err = ErrUnsupportedType
 	}
 
-End:
 	if err != nil {
-		err = c.wrapConvertError(c.value, reflect.ValueOf(value).Type(), err)
+		err = c.wrapConvertError(c.value, value.Type(), err)
 	}
 
-	if c.isNil {
-		return &MapConverter{baseConverter: c.baseConverter, value: nil, err: err}
-	}
 	return &MapConverter{baseConverter: c.baseConverter, value: value, err: err}
 }
 
@@ -173,7 +158,7 @@ func (c *ValueConverter) jsonMapWithDepth(depth uint) *JSONMapConverter {
 // MapConverter is a converter that converts a map type to another type.
 type MapConverter struct {
 	*baseConverter
-	value map[interface{}]interface{}
+	value reflect.Value
 	err   error
 }
 
@@ -189,7 +174,7 @@ func (c *MapConverter) Convert(out interface{}) error {
 
 func (c *MapConverter) convert(outV reflect.Value) error {
 	if c.err != nil {
-		return c.wrapConvertError(c.value, outV.Type(), c.err)
+		return c.wrapConvertError(c.value.Interface(), outV.Type(), c.err)
 	}
 	if c.isNil {
 		return nil
@@ -207,26 +192,28 @@ func (c *MapConverter) convert(outV reflect.Value) error {
 		if outV.IsNil() {
 			outV.Set(reflect.MakeMap(outV.Type()))
 		}
-		for k, v := range c.value {
+		iter := c.value.MapRange()
+		for iter.Next() {
 			keyV := reflect.New(outV.Type().Key())
 			valueV := reflect.New(outV.Type().Elem())
 			strKey := New(keyV).String().Value()
-			if err := c.new(k, c.field+"[]"+strKey).convert(keyV); err != nil {
+			if err := c.new(iter.Key().Interface(), c.field+"[]"+strKey).convert(keyV); err != nil {
 				return err
 			}
-			if err := c.new(v, c.field+"["+strKey+"]").convert(valueV); err != nil {
+			if err := c.new(iter.Value().Interface(), c.field+"["+strKey+"]").convert(valueV); err != nil {
 				return err
 			}
 			outV.SetMapIndex(keyV.Elem(), valueV.Elem())
 		}
 	case reflect.Struct:
 		m := map[string]interface{}{}
-		for k, v := range c.value {
-			strKey, err := c.new(k, c.field+"[]").String().Result()
+		iter := c.value.MapRange()
+		for iter.Next() {
+			strKey, err := c.new(iter.Key().Interface(), c.field+"[]").String().Result()
 			if err != nil {
 				return err
 			}
-			m[strKey] = v
+			m[strKey] = iter.Value().Interface()
 		}
 
 		for _, outField := range getStructFields(outV.Type()) {
@@ -254,23 +241,32 @@ func (c *MapConverter) convert(outV reflect.Value) error {
 			}
 		}
 	default:
-		return c.wrapConvertError(c.value, outV.Type(), ErrUnsupportedType)
+		return c.wrapConvertError(c.value.Interface(), outV.Type(), ErrUnsupportedType)
 	}
 	return nil
 }
 
 // Result returns the conversion result and error.
 func (c *MapConverter) Result() (map[interface{}]interface{}, error) {
-	return c.value, c.err
+	if c.isNil {
+		return nil, c.err
+	}
+	return c.value.Interface().(map[interface{}]interface{}), c.err
 }
 
 // Value returns the conversion result.
 func (c *MapConverter) Value() map[interface{}]interface{} {
-	return c.value
+	if c.isNil {
+		return nil
+	}
+	return c.value.Interface().(map[interface{}]interface{})
 }
 
 // Interface returns the conversion result of interface type.
 func (c *MapConverter) Interface() interface{} {
+	if c.isNil {
+		return nil
+	}
 	return c.value
 }
 

--- a/map.go
+++ b/map.go
@@ -71,9 +71,9 @@ func (c *ValueConverter) mapWithDepth(depth uint) *MapConverter {
 	}
 
 	if c.isNil {
-		return &MapConverter{converter: c.converter, value: nil, err: err}
+		return &MapConverter{baseConverter: c.baseConverter, value: nil, err: err}
 	}
-	return &MapConverter{converter: c.converter, value: value, err: err}
+	return &MapConverter{baseConverter: c.baseConverter, value: value, err: err}
 }
 
 func (c *ValueConverter) jsonMapWithDepth(depth uint) *JSONMapConverter {
@@ -135,14 +135,14 @@ func (c *ValueConverter) jsonMapWithDepth(depth uint) *JSONMapConverter {
 	}
 
 	if c.isNil {
-		return &JSONMapConverter{converter: c.converter, value: nil, err: err}
+		return &JSONMapConverter{baseConverter: c.baseConverter, value: nil, err: err}
 	}
-	return &JSONMapConverter{converter: c.converter, value: value, err: err}
+	return &JSONMapConverter{baseConverter: c.baseConverter, value: value, err: err}
 }
 
 // MapConverter is a converter that converts a map type to another type.
 type MapConverter struct {
-	converter
+	baseConverter
 	value map[interface{}]interface{}
 	err   error
 }
@@ -239,6 +239,11 @@ func (c *MapConverter) Value() map[interface{}]interface{} {
 	return c.value
 }
 
+// Interface returns the conversion result of interface type.
+func (c *MapConverter) Interface() interface{} {
+	return c.value
+}
+
 // Error returns an error if the conversion fails.
 func (c *MapConverter) Error() error {
 	return c.err
@@ -246,7 +251,7 @@ func (c *MapConverter) Error() error {
 
 // JSONMapConverter is a converter that converts a json map type to another type.
 type JSONMapConverter struct {
-	converter
+	baseConverter
 	value map[string]interface{}
 	err   error
 }
@@ -258,6 +263,11 @@ func (c *JSONMapConverter) Result() (map[string]interface{}, error) {
 
 // Value returns the conversion result.
 func (c *JSONMapConverter) Value() map[string]interface{} {
+	return c.value
+}
+
+// Interface returns the conversion result of interface type.
+func (c *JSONMapConverter) Interface() interface{} {
 	return c.value
 }
 

--- a/map.go
+++ b/map.go
@@ -51,11 +51,14 @@ func (c *ValueConverter) mapWithDepth(depth uint) *MapConverter {
 		})()
 
 		switch reflect.Indirect(reflect.ValueOf(vVal.Interface())).Kind() {
-		case reflect.Struct, reflect.Map:
+		case reflect.Struct:
 			if converted, ok := c.opts.mapOpts.structValueConversionFunc(vVal.Interface()); ok {
-				value.SetMapIndex(convertedKeyVal, reflect.ValueOf(converted))
+				value.SetMapIndex(convertedKeyVal, reflect.ValueOf(&converted).Elem())
 				break
-			} else if depth < c.opts.mapOpts.maxDepth {
+			}
+			fallthrough
+		case reflect.Map:
+			if depth < c.opts.mapOpts.maxDepth {
 				conv := c.new(vVal.Interface(), c.field+"."+strKey).mapWithDepth(depth + 1)
 				if err = conv.err; err != nil {
 					return

--- a/map.go
+++ b/map.go
@@ -52,7 +52,10 @@ func (c *ValueConverter) mapWithDepth(depth uint) *MapConverter {
 
 		switch reflect.Indirect(reflect.ValueOf(vVal.Interface())).Kind() {
 		case reflect.Struct, reflect.Map:
-			if depth < c.opts.mapOpts.maxDepth {
+			if converted, ok := c.opts.mapOpts.structValueConversionFunc(vVal.Interface()); ok {
+				value.SetMapIndex(convertedKeyVal, reflect.ValueOf(converted))
+				break
+			} else if depth < c.opts.mapOpts.maxDepth {
 				conv := c.new(vVal.Interface(), c.field+"."+strKey).mapWithDepth(depth + 1)
 				if err = conv.err; err != nil {
 					return

--- a/options.go
+++ b/options.go
@@ -15,6 +15,10 @@ type (
 	// RoundingFunc is a function that rounds from float to nearest integer.
 	// e.g. math.Floor
 	RoundingFunc func(float64) float64
+	// KeyConversionFunc is a conversion function of keys.
+	KeyConversionFunc func(keyConverter *ValueConverter) Converter
+	// ValueConversionFunc is a conversion function of values.
+	ValueConversionFunc func(key interface{}, valueConverter *ValueConverter) Converter
 )
 
 type (
@@ -26,8 +30,10 @@ type (
 		prec int
 	}
 	mapOpts struct {
-		maxDepth   uint
-		filterFuns mapFilterFuns
+		maxDepth            uint
+		filterFuns          mapFilterFuns
+		keyConversionFunc   KeyConversionFunc
+		valueConversionFunc ValueConversionFunc
 	}
 	mapFilterFuns []func(k interface{}, v interface{}) bool
 )
@@ -53,6 +59,12 @@ func defaultConverterOpts() ConverterOpts {
 		mapOpts: mapOpts{
 			maxDepth:   ^uint(0),
 			filterFuns: make(mapFilterFuns, 0),
+			keyConversionFunc: func(keyConverter *ValueConverter) Converter {
+				return keyConverter
+			},
+			valueConversionFunc: func(key interface{}, valueConverter *ValueConverter) Converter {
+				return valueConverter
+			},
 		},
 	}
 }
@@ -72,6 +84,24 @@ func WithFloatFormat(fmt byte, prec int) func(*ConverterOpts) {
 func WithRoundingFunc(f RoundingFunc) func(*ConverterOpts) {
 	return func(opt *ConverterOpts) {
 		opt.numOpts.roundingFunc = f
+	}
+}
+
+// WithMapKeyConverter is an option when converting to map.
+//
+// It can be used when converting keys to other types.
+func WithMapKeyConverter(f KeyConversionFunc) func(*ConverterOpts) {
+	return func(opt *ConverterOpts) {
+		opt.mapOpts.keyConversionFunc = f
+	}
+}
+
+// WithMapValueConverter is an option when converting to map.
+//
+// It can be used when converting values to other types.
+func WithMapValueConverter(f ValueConversionFunc) func(*ConverterOpts) {
+	return func(opt *ConverterOpts) {
+		opt.mapOpts.valueConversionFunc = f
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -42,10 +42,15 @@ type (
 	mapOpts struct {
 		maxDepth            uint
 		filterFuns          mapFilterFuns
+		keyType             reflect.Type
 		keyConversionFunc   ConversionFunc
 		valueConversionFunc ConversionFunc
 	}
 	mapFilterFuns []func(k interface{}, v interface{}) bool
+)
+
+var (
+	interfaceType = reflect.ValueOf([]interface{}{}).Type().Elem()
 )
 
 func (fs mapFilterFuns) All(k interface{}, v interface{}) bool {
@@ -70,9 +75,10 @@ func defaultConverterOpts() ConverterOpts {
 			valueConversionFunc: DefaultConversionFunc,
 		},
 		mapOpts: mapOpts{
-			maxDepth:   ^uint(0),
-			filterFuns: make(mapFilterFuns, 0),
-			keyConversionFunc: DefaultConversionFunc,
+			maxDepth:            ^uint(0),
+			filterFuns:          make(mapFilterFuns, 0),
+			keyType:             interfaceType,
+			keyConversionFunc:   DefaultConversionFunc,
 			valueConversionFunc: DefaultConversionFunc,
 		},
 	}

--- a/options_test.go
+++ b/options_test.go
@@ -100,7 +100,7 @@ func ExampleWithMapValueConverter() {
 	in := map[interface{}]interface{}{
 		"a": map[interface{}]interface{}{"a.1": 1.5, "a.2": 1},
 		"b": map[interface{}]interface{}{"b.1": 2.5, "b.2": 2},
-		"c": struct { X float64 }{X: 3.5},
+		"c": struct{ X float64 }{X: 3.5},
 	}
 
 	fmt.Printf(

--- a/options_test.go
+++ b/options_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"time"
 )
 
 func ExampleWithFloatFormat() {
@@ -118,6 +119,54 @@ func ExampleWithMapValueConverter() {
 	// Output:
 	// Default:               map[a:map[a.1:1.5 a.2:1] b:map[b.1:2.5 b.2:2] c:map[X:3.5]]
 	// Convert values to int: map[a:map[a.1:1 a.2:1] b:map[b.1:2 b.2:2] c:map[X:3]]
+}
+
+func ExampleWithMapStructValueConverter() {
+	in := map[interface{}]interface{}{
+		"Name":      "Alice",
+		"Age":       30,
+		"CreatedAt": time.Unix(1257894000, 0),
+	}
+
+	fmt.Printf(
+		"Default:        %v\n",
+		New(in).Map().Value(),
+	)
+	fmt.Printf(
+		"Time to string: %v\n",
+		New(in, WithMapStructValueConverter(func(value interface{}) (out interface{}, ok bool) {
+			var t time.Time
+			if err := New(value).As(&t); err != nil {
+				return nil, false
+			}
+			return t.String(), true
+		})).Map().Value(),
+	)
+
+	// Output:
+	// Default:        map[Age:30 CreatedAt:map[] Name:Alice]
+	// Time to string: map[Age:30 CreatedAt:2009-11-11 08:00:00 +0900 JST Name:Alice]
+}
+
+func ExampleWithMapTimeValueStringConverter() {
+	in := map[interface{}]interface{}{
+		"Name":      "Alice",
+		"Age":       30,
+		"CreatedAt": time.Unix(1257894000, 0).UTC(),
+	}
+
+	fmt.Printf(
+		"Default:        %v\n",
+		New(in).Map().Value(),
+	)
+	fmt.Printf(
+		"Time to string: %v\n",
+		New(in, WithMapTimeValueStringConverter(time.RFC3339)).Map().Value(),
+	)
+
+	// Output:
+	// Default:        map[Age:30 CreatedAt:map[] Name:Alice]
+	// Time to string: map[Age:30 CreatedAt:2009-11-10T23:00:00Z Name:Alice]
 }
 
 func ExampleWithMapMaxDepth() {

--- a/options_test.go
+++ b/options_test.go
@@ -53,6 +53,26 @@ func ExampleWithRoundingFunc() {
 	// WithRoundingFunc(math.Ceil): 2
 }
 
+func ExampleWithSliceValueConverter() {
+	in := []string{"1.5", "2", "2.5"}
+
+	fmt.Printf(
+		"Default:              %v\n",
+		New(in).Slice().Value(),
+	)
+
+	fmt.Printf(
+		"Convert value to int: %v\n",
+		New(in, WithSliceValueConverter(func(converter *ValueConverter) Converter {
+			return converter.Float().Int()
+		})).Slice().Value(),
+	)
+
+	// Output:
+	// Default:              [1.5 2 2.5]
+	// Convert value to int: [1 2 2]
+}
+
 func ExampleWithMapKeyConverter() {
 	in := map[interface{}]interface{}{
 		"1.0": map[float64]interface{}{1.5: "a"},
@@ -66,8 +86,8 @@ func ExampleWithMapKeyConverter() {
 
 	fmt.Printf(
 		"Convert key to int: %v\n",
-		New(in, WithMapKeyConverter(func(keyConverter *ValueConverter) Converter {
-			return keyConverter.Float().Int()
+		New(in, WithMapKeyConverter(func(converter *ValueConverter) Converter {
+			return converter.Float().Int()
 		})).Map().Value(),
 	)
 
@@ -84,23 +104,20 @@ func ExampleWithMapValueConverter() {
 	}
 
 	fmt.Printf(
-		"Default:                          %v\n",
+		"Default:               %v\n",
 		New(in).Map().Value(),
 	)
 
 	fmt.Printf(
-		"Convert values of b and c to int: %v\n",
-		New(in, WithMapValueConverter(func(key interface{}, keyConverter *ValueConverter) Converter {
-			if key == "a.1" || key == "a.2" {
-				return keyConverter
-			}
-			return keyConverter.Float().Int()
+		"Convert values to int: %v\n",
+		New(in, WithMapValueConverter(func(converter *ValueConverter) Converter {
+			return converter.Float().Int()
 		})).Map().Value(),
 	)
 
 	// Output:
-	// Default:                          map[a:map[a.1:1.5 a.2:1] b:map[b.1:2.5 b.2:2] c:map[X:3.5]]
-	// Convert values of b and c to int: map[a:map[a.1:1.5 a.2:1] b:map[b.1:2 b.2:2] c:map[X:3]]
+	// Default:               map[a:map[a.1:1.5 a.2:1] b:map[b.1:2.5 b.2:2] c:map[X:3.5]]
+	// Convert values to int: map[a:map[a.1:1 a.2:1] b:map[b.1:2 b.2:2] c:map[X:3]]
 }
 
 func ExampleWithMapMaxDepth() {

--- a/options_test.go
+++ b/options_test.go
@@ -53,6 +53,56 @@ func ExampleWithRoundingFunc() {
 	// WithRoundingFunc(math.Ceil): 2
 }
 
+func ExampleWithMapKeyConverter() {
+	in := map[interface{}]interface{}{
+		"1.0": map[float64]interface{}{1.5: "a"},
+		"2.0": map[uint64]interface{}{2: "b"},
+	}
+
+	fmt.Printf(
+		"Default:            %v\n",
+		New(in).Map().Value(),
+	)
+
+	fmt.Printf(
+		"Convert key to int: %v\n",
+		New(in, WithMapKeyConverter(func(keyConverter *ValueConverter) Converter {
+			return keyConverter.Float().Int()
+		})).Map().Value(),
+	)
+
+	// Output:
+	// Default:            map[1.0:map[1.5:a] 2.0:map[2:b]]
+	// Convert key to int: map[1:map[1:a] 2:map[2:b]]
+}
+
+func ExampleWithMapValueConverter() {
+	in := map[interface{}]interface{}{
+		"a": map[interface{}]interface{}{"a.1": 1.5, "a.2": 1},
+		"b": map[interface{}]interface{}{"b.1": 2.5, "b.2": 2},
+		"c": struct { X float64 }{X: 3.5},
+	}
+
+	fmt.Printf(
+		"Default:                          %v\n",
+		New(in).Map().Value(),
+	)
+
+	fmt.Printf(
+		"Convert values of b and c to int: %v\n",
+		New(in, WithMapValueConverter(func(key interface{}, keyConverter *ValueConverter) Converter {
+			if key == "a.1" || key == "a.2" {
+				return keyConverter
+			}
+			return keyConverter.Float().Int()
+		})).Map().Value(),
+	)
+
+	// Output:
+	// Default:                          map[a:map[a.1:1.5 a.2:1] b:map[b.1:2.5 b.2:2] c:map[X:3.5]]
+	// Convert values of b and c to int: map[a:map[a.1:1.5 a.2:1] b:map[b.1:2 b.2:2] c:map[X:3]]
+}
+
 func ExampleWithMapMaxDepth() {
 	type Nested struct {
 		Y string

--- a/options_test.go
+++ b/options_test.go
@@ -125,7 +125,7 @@ func ExampleWithMapStructValueConverter() {
 	in := map[interface{}]interface{}{
 		"Name":      "Alice",
 		"Age":       30,
-		"CreatedAt": time.Unix(1257894000, 0),
+		"CreatedAt": time.Unix(1257894000, 0).UTC(),
 	}
 
 	fmt.Printf(
@@ -145,7 +145,7 @@ func ExampleWithMapStructValueConverter() {
 
 	// Output:
 	// Default:        map[Age:30 CreatedAt:map[] Name:Alice]
-	// Time to string: map[Age:30 CreatedAt:2009-11-11 08:00:00 +0900 JST Name:Alice]
+	// Time to string: map[Age:30 CreatedAt:2009-11-10 23:00:00 +0000 UTC Name:Alice]
 }
 
 func ExampleWithMapTimeValueStringConverter() {

--- a/slice.go
+++ b/slice.go
@@ -25,9 +25,9 @@ func (c *ValueConverter) Slice() *SliceConverter {
 	}
 
 	if c.isNil {
-		return &SliceConverter{converter: c.converter, value: nil, err: err}
+		return &SliceConverter{baseConverter: c.baseConverter, value: nil, err: err}
 	}
-	return &SliceConverter{converter: c.converter, value: value, err: err}
+	return &SliceConverter{baseConverter: c.baseConverter, value: value, err: err}
 }
 
 // StringSlice converts the input to slice of string type.
@@ -52,7 +52,7 @@ func (c *ValueConverter) FloatSlice() *FloatSliceConverter {
 
 // SliceConverter is a converter that converts a slice type to another type.
 type SliceConverter struct {
-	converter
+	baseConverter
 	value []interface{}
 	err   error
 }
@@ -128,10 +128,10 @@ func (c *SliceConverter) IntSlice() *IntegerSliceConverter {
 		fieldName := c.field + "[" + New(i).String().Value() + "]"
 		value[i], err = c.new(v, fieldName).Int().Result()
 		if err != nil {
-			return &IntegerSliceConverter{converter: c.converter, value: nil, err: err}
+			return &IntegerSliceConverter{baseConverter: c.baseConverter, value: nil, err: err}
 		}
 	}
-	return &IntegerSliceConverter{converter: c.converter, value: value, err: nil}
+	return &IntegerSliceConverter{baseConverter: c.baseConverter, value: value, err: nil}
 }
 
 // UintSlice converts the input to slice of uint type.
@@ -145,10 +145,10 @@ func (c *SliceConverter) UintSlice() *UnsignedIntegerSliceConverter {
 		fieldName := c.field + "[" + New(i).String().Value() + "]"
 		value[i], err = c.new(v, fieldName).Uint().Result()
 		if err != nil {
-			return &UnsignedIntegerSliceConverter{converter: c.converter, value: nil, err: err}
+			return &UnsignedIntegerSliceConverter{baseConverter: c.baseConverter, value: nil, err: err}
 		}
 	}
-	return &UnsignedIntegerSliceConverter{converter: c.converter, value: value, err: nil}
+	return &UnsignedIntegerSliceConverter{baseConverter: c.baseConverter, value: value, err: nil}
 }
 
 // FloatSlice converts the input to slice of float type.
@@ -162,10 +162,10 @@ func (c *SliceConverter) FloatSlice() *FloatSliceConverter {
 		fieldName := c.field + "[" + New(i).String().Value() + "]"
 		value[i], err = c.new(v, fieldName).Float().Result()
 		if err != nil {
-			return &FloatSliceConverter{converter: c.converter, value: nil, err: err}
+			return &FloatSliceConverter{baseConverter: c.baseConverter, value: nil, err: err}
 		}
 	}
-	return &FloatSliceConverter{converter: c.converter, value: value, err: nil}
+	return &FloatSliceConverter{baseConverter: c.baseConverter, value: value, err: nil}
 }
 
 // StringSlice converts the input to slice of string type.
@@ -179,10 +179,10 @@ func (c *SliceConverter) StringSlice() *StringSliceConverter {
 		fieldName := c.field + "[" + New(i).String().Value() + "]"
 		value[i], err = c.new(v, fieldName).String().Result()
 		if err != nil {
-			return &StringSliceConverter{converter: c.converter, value: nil, err: err}
+			return &StringSliceConverter{baseConverter: c.baseConverter, value: nil, err: err}
 		}
 	}
-	return &StringSliceConverter{converter: c.converter, value: value, err: nil}
+	return &StringSliceConverter{baseConverter: c.baseConverter, value: value, err: nil}
 }
 
 // Result returns the conversion result and error
@@ -195,6 +195,11 @@ func (c *SliceConverter) Value() []interface{} {
 	return c.value
 }
 
+// Interface returns the conversion result of interface type.
+func (c *SliceConverter) Interface() interface{} {
+	return c.value
+}
+
 // Error returns an error if the conversion fails.
 func (c *SliceConverter) Error() error {
 	return c.err
@@ -202,7 +207,7 @@ func (c *SliceConverter) Error() error {
 
 // IntegerSliceConverter is a converter that converts a slice of integer type to another type.
 type IntegerSliceConverter struct {
-	converter
+	baseConverter
 	value []int64
 	err   error
 }
@@ -217,6 +222,11 @@ func (c *IntegerSliceConverter) Value() []int64 {
 	return c.value
 }
 
+// Interface returns the conversion result of interface type.
+func (c *IntegerSliceConverter) Interface() interface{} {
+	return c.value
+}
+
 // Error returns an error if the conversion fails.
 func (c *IntegerSliceConverter) Error() error {
 	return c.err
@@ -224,7 +234,7 @@ func (c *IntegerSliceConverter) Error() error {
 
 // UnsignedIntegerSliceConverter is a converter that converts a slice of uint type to another type.
 type UnsignedIntegerSliceConverter struct {
-	converter
+	baseConverter
 	value []uint64
 	err   error
 }
@@ -239,6 +249,11 @@ func (c *UnsignedIntegerSliceConverter) Value() []uint64 {
 	return c.value
 }
 
+// Interface returns the conversion result of interface type.
+func (c *UnsignedIntegerConverter) Interface() interface{} {
+	return c.value
+}
+
 // Error returns an error if the conversion fails.
 func (c *UnsignedIntegerSliceConverter) Error() error {
 	return c.err
@@ -246,7 +261,7 @@ func (c *UnsignedIntegerSliceConverter) Error() error {
 
 // FloatSliceConverter is a converter that converts a slice of float type to another type.
 type FloatSliceConverter struct {
-	converter
+	baseConverter
 	value []float64
 	err   error
 }
@@ -261,6 +276,11 @@ func (c *FloatSliceConverter) Value() []float64 {
 	return c.value
 }
 
+// Interface returns the conversion result of interface type.
+func (c *FloatSliceConverter) Interface() interface{} {
+	return c.value
+}
+
 // Error returns an error if the conversion fails.
 func (c *FloatSliceConverter) Error() error {
 	return c.err
@@ -268,7 +288,7 @@ func (c *FloatSliceConverter) Error() error {
 
 // StringSliceConverter is a converter that converts a slice of string type to another type.
 type StringSliceConverter struct {
-	converter
+	baseConverter
 	value []string
 	err   error
 }
@@ -280,6 +300,11 @@ func (c *StringSliceConverter) Result() ([]string, error) {
 
 // Value returns the conversion result.
 func (c *StringSliceConverter) Value() []string {
+	return c.value
+}
+
+// Interface returns the conversion result of interface type.
+func (c *StringSliceConverter) Interface() interface{} {
 	return c.value
 }
 

--- a/slice.go
+++ b/slice.go
@@ -2,6 +2,47 @@ package henge
 
 import "reflect"
 
+type (
+	// SliceConverter is a converter that converts a slice type to another type.
+	SliceConverter struct {
+		*baseConverter
+		value []interface{}
+		err   error
+	}
+
+	// IntegerSliceConverter is a converter that converts a slice of integer type to another type.
+	IntegerSliceConverter struct {
+		*baseConverter
+		value []int64
+		err   error
+	}
+
+	// UnsignedIntegerSliceConverter is a converter that converts a slice of uint type to another type.
+	UnsignedIntegerSliceConverter struct {
+		*baseConverter
+		value []uint64
+		err   error
+	}
+
+	// FloatSliceConverter is a converter that converts a slice of float type to another type.
+	FloatSliceConverter struct {
+		*baseConverter
+		value []float64
+		err   error
+	}
+
+	// StringSliceConverter is a converter that converts a slice of string type to another type.
+	StringSliceConverter struct {
+		*baseConverter
+		value []string
+		err   error
+	}
+)
+
+// --------------------------------------------------------------------- //
+// ValueConverter
+// --------------------------------------------------------------------- //
+
 // Slice converts the input to slice type.
 func (c *ValueConverter) Slice() *SliceConverter {
 	var (
@@ -54,12 +95,9 @@ func (c *ValueConverter) FloatSlice() *FloatSliceConverter {
 	return c.Slice().FloatSlice()
 }
 
-// SliceConverter is a converter that converts a slice type to another type.
-type SliceConverter struct {
-	*baseConverter
-	value []interface{}
-	err   error
-}
+// --------------------------------------------------------------------- //
+// SliceConverter
+// --------------------------------------------------------------------- //
 
 // Convert converts the input to the out type and assigns it.
 // If the conversion fails, the method returns an error.
@@ -123,68 +161,36 @@ func (c *SliceConverter) convert(outV reflect.Value) error {
 
 // IntSlice converts the input to slice of int type.
 func (c *SliceConverter) IntSlice() *IntegerSliceConverter {
-	var (
-		value []int64 = make([]int64, len(c.value))
-		err   error
-	)
-
-	for i, v := range c.value {
-		fieldName := c.field + "[" + New(i).String().Value() + "]"
-		value[i], err = c.new(v, fieldName).Int().Result()
-		if err != nil {
-			return &IntegerSliceConverter{baseConverter: c.baseConverter, value: nil, err: err}
-		}
+	var value []int64
+	if err := c.Convert(&value); err != nil {
+		return &IntegerSliceConverter{baseConverter: c.baseConverter, value: value, err: err}
 	}
 	return &IntegerSliceConverter{baseConverter: c.baseConverter, value: value, err: nil}
 }
 
 // UintSlice converts the input to slice of uint type.
 func (c *SliceConverter) UintSlice() *UnsignedIntegerSliceConverter {
-	var (
-		value []uint64 = make([]uint64, len(c.value))
-		err   error
-	)
-
-	for i, v := range c.value {
-		fieldName := c.field + "[" + New(i).String().Value() + "]"
-		value[i], err = c.new(v, fieldName).Uint().Result()
-		if err != nil {
-			return &UnsignedIntegerSliceConverter{baseConverter: c.baseConverter, value: nil, err: err}
-		}
+	var value []uint64
+	if err := c.Convert(&value); err != nil {
+		return &UnsignedIntegerSliceConverter{baseConverter: c.baseConverter, value: value, err: err}
 	}
 	return &UnsignedIntegerSliceConverter{baseConverter: c.baseConverter, value: value, err: nil}
 }
 
 // FloatSlice converts the input to slice of float type.
 func (c *SliceConverter) FloatSlice() *FloatSliceConverter {
-	var (
-		value []float64 = make([]float64, len(c.value))
-		err   error
-	)
-
-	for i, v := range c.value {
-		fieldName := c.field + "[" + New(i).String().Value() + "]"
-		value[i], err = c.new(v, fieldName).Float().Result()
-		if err != nil {
-			return &FloatSliceConverter{baseConverter: c.baseConverter, value: nil, err: err}
-		}
+	var value []float64
+	if err := c.Convert(&value); err != nil {
+		return &FloatSliceConverter{baseConverter: c.baseConverter, value: value, err: err}
 	}
 	return &FloatSliceConverter{baseConverter: c.baseConverter, value: value, err: nil}
 }
 
 // StringSlice converts the input to slice of string type.
 func (c *SliceConverter) StringSlice() *StringSliceConverter {
-	var (
-		value []string = make([]string, len(c.value))
-		err   error
-	)
-
-	for i, v := range c.value {
-		fieldName := c.field + "[" + New(i).String().Value() + "]"
-		value[i], err = c.new(v, fieldName).String().Result()
-		if err != nil {
-			return &StringSliceConverter{baseConverter: c.baseConverter, value: nil, err: err}
-		}
+	var value []string
+	if err := c.Convert(&value); err != nil {
+		return &StringSliceConverter{baseConverter: c.baseConverter, value: value, err: err}
 	}
 	return &StringSliceConverter{baseConverter: c.baseConverter, value: value, err: nil}
 }
@@ -209,12 +215,9 @@ func (c *SliceConverter) Error() error {
 	return c.err
 }
 
-// IntegerSliceConverter is a converter that converts a slice of integer type to another type.
-type IntegerSliceConverter struct {
-	*baseConverter
-	value []int64
-	err   error
-}
+// --------------------------------------------------------------------- //
+// IntegerSliceConverter
+// --------------------------------------------------------------------- //
 
 // Result returns the conversion result and error
 func (c *IntegerSliceConverter) Result() ([]int64, error) {
@@ -236,12 +239,9 @@ func (c *IntegerSliceConverter) Error() error {
 	return c.err
 }
 
-// UnsignedIntegerSliceConverter is a converter that converts a slice of uint type to another type.
-type UnsignedIntegerSliceConverter struct {
-	*baseConverter
-	value []uint64
-	err   error
-}
+// --------------------------------------------------------------------- //
+// UnsignedIntegerSliceConverter
+// --------------------------------------------------------------------- //
 
 // Result returns the conversion result and error.
 func (c *UnsignedIntegerSliceConverter) Result() ([]uint64, error) {
@@ -263,12 +263,9 @@ func (c *UnsignedIntegerSliceConverter) Error() error {
 	return c.err
 }
 
-// FloatSliceConverter is a converter that converts a slice of float type to another type.
-type FloatSliceConverter struct {
-	*baseConverter
-	value []float64
-	err   error
-}
+// --------------------------------------------------------------------- //
+// FloatSliceConverter
+// --------------------------------------------------------------------- //
 
 // Result returns the conversion result and error.
 func (c *FloatSliceConverter) Result() ([]float64, error) {
@@ -290,12 +287,9 @@ func (c *FloatSliceConverter) Error() error {
 	return c.err
 }
 
-// StringSliceConverter is a converter that converts a slice of string type to another type.
-type StringSliceConverter struct {
-	*baseConverter
-	value []string
-	err   error
-}
+// --------------------------------------------------------------------- //
+// StringSliceConverter
+// --------------------------------------------------------------------- //
 
 // Result returns the conversion result and error.
 func (c *StringSliceConverter) Result() ([]string, error) {

--- a/slice.go
+++ b/slice.go
@@ -9,7 +9,7 @@ func (c *ValueConverter) Slice() *SliceConverter {
 		err   error
 	)
 
-	inV := reflect.Indirect(reflect.ValueOf(c.value))
+	inV := reflect.Indirect(c.reflectValue)
 	switch inV.Kind() {
 	case reflect.Array, reflect.Slice:
 		value = make([]interface{}, inV.Len())

--- a/slice.go
+++ b/slice.go
@@ -14,7 +14,11 @@ func (c *ValueConverter) Slice() *SliceConverter {
 	case reflect.Array, reflect.Slice:
 		value = make([]interface{}, inV.Len())
 		for i := 0; i < inV.Len(); i++ {
-			value[i] = inV.Index(i).Interface()
+			vConv := c.opts.sliceOpts.valueConversionFunc(c.new(inV.Index(i).Interface(), c.field+"["+New(i).String().Value()+"]"))
+			if err = vConv.Error(); err != nil {
+				break
+			}
+			value[i] = vConv.Interface()
 		}
 	default:
 		err = ErrUnsupportedType

--- a/slice.go
+++ b/slice.go
@@ -250,7 +250,7 @@ func (c *UnsignedIntegerSliceConverter) Value() []uint64 {
 }
 
 // Interface returns the conversion result of interface type.
-func (c *UnsignedIntegerConverter) Interface() interface{} {
+func (c *UnsignedIntegerSliceConverter) Interface() interface{} {
 	return c.value
 }
 

--- a/slice.go
+++ b/slice.go
@@ -52,7 +52,7 @@ func (c *ValueConverter) FloatSlice() *FloatSliceConverter {
 
 // SliceConverter is a converter that converts a slice type to another type.
 type SliceConverter struct {
-	baseConverter
+	*baseConverter
 	value []interface{}
 	err   error
 }
@@ -207,7 +207,7 @@ func (c *SliceConverter) Error() error {
 
 // IntegerSliceConverter is a converter that converts a slice of integer type to another type.
 type IntegerSliceConverter struct {
-	baseConverter
+	*baseConverter
 	value []int64
 	err   error
 }
@@ -234,7 +234,7 @@ func (c *IntegerSliceConverter) Error() error {
 
 // UnsignedIntegerSliceConverter is a converter that converts a slice of uint type to another type.
 type UnsignedIntegerSliceConverter struct {
-	baseConverter
+	*baseConverter
 	value []uint64
 	err   error
 }
@@ -261,7 +261,7 @@ func (c *UnsignedIntegerSliceConverter) Error() error {
 
 // FloatSliceConverter is a converter that converts a slice of float type to another type.
 type FloatSliceConverter struct {
-	baseConverter
+	*baseConverter
 	value []float64
 	err   error
 }
@@ -288,7 +288,7 @@ func (c *FloatSliceConverter) Error() error {
 
 // StringSliceConverter is a converter that converts a slice of string type to another type.
 type StringSliceConverter struct {
-	baseConverter
+	*baseConverter
 	value []string
 	err   error
 }

--- a/string.go
+++ b/string.go
@@ -5,6 +5,26 @@ import (
 	"strconv"
 )
 
+type (
+	// StringConverter is a converter that converts a string type to another type.
+	StringConverter struct {
+		*baseConverter
+		value string
+		err   error
+	}
+
+	// StringPtrConverter is a converter that converts a pointer of string type to another type.
+	StringPtrConverter struct {
+		*baseConverter
+		value *string
+		err   error
+	}
+)
+
+// --------------------------------------------------------------------- //
+// ValueConverter
+// --------------------------------------------------------------------- //
+
 // String converts the input to string type.
 func (c *ValueConverter) String() *StringConverter {
 	var (
@@ -57,12 +77,9 @@ func (c *ValueConverter) StringPtr() *StringPtrConverter {
 	return c.String().Ptr()
 }
 
-// StringConverter is a converter that converts a string type to another type.
-type StringConverter struct {
-	*baseConverter
-	value string
-	err   error
-}
+// --------------------------------------------------------------------- //
+// StringConverter
+// --------------------------------------------------------------------- //
 
 // Ptr converts the input to ptr type.
 func (c *StringConverter) Ptr() *StringPtrConverter {
@@ -121,12 +138,9 @@ func (c *StringConverter) Error() error {
 	return c.err
 }
 
-// StringPtrConverter is a converter that converts a pointer of string type to another type.
-type StringPtrConverter struct {
-	*baseConverter
-	value *string
-	err   error
-}
+// --------------------------------------------------------------------- //
+// StringPtrConverter
+// --------------------------------------------------------------------- //
 
 // Result returns the conversion result and error.
 func (c *StringPtrConverter) Result() (*string, error) {

--- a/string.go
+++ b/string.go
@@ -49,7 +49,7 @@ func (c *ValueConverter) String() *StringConverter {
 	if err != nil {
 		err = c.wrapConvertError(c.value, reflect.ValueOf((*string)(nil)).Type().Elem(), err)
 	}
-	return &StringConverter{converter: c.converter, value: value, err: err}
+	return &StringConverter{baseConverter: c.baseConverter, value: value, err: err}
 }
 
 // StringPtr converts the input to pointer of string type.
@@ -59,7 +59,7 @@ func (c *ValueConverter) StringPtr() *StringPtrConverter {
 
 // StringConverter is a converter that converts a string type to another type.
 type StringConverter struct {
-	converter
+	baseConverter
 	value string
 	err   error
 }
@@ -67,9 +67,9 @@ type StringConverter struct {
 // Ptr converts the input to ptr type.
 func (c *StringConverter) Ptr() *StringPtrConverter {
 	if c.err != nil || c.isNil {
-		return &StringPtrConverter{converter: c.converter, value: nil, err: c.err}
+		return &StringPtrConverter{baseConverter: c.baseConverter, value: nil, err: c.err}
 	}
-	return &StringPtrConverter{converter: c.converter, value: &c.value, err: nil}
+	return &StringPtrConverter{baseConverter: c.baseConverter, value: &c.value, err: nil}
 }
 
 // Convert converts the input to the out type and assigns it.
@@ -111,6 +111,11 @@ func (c *StringConverter) Value() string {
 	return c.value
 }
 
+// Interface returns the conversion result of interface type.
+func (c *StringConverter) Interface() interface{} {
+	return c.value
+}
+
 // Error returns an error if the conversion fails.
 func (c *StringConverter) Error() error {
 	return c.err
@@ -118,7 +123,7 @@ func (c *StringConverter) Error() error {
 
 // StringPtrConverter is a converter that converts a pointer of string type to another type.
 type StringPtrConverter struct {
-	converter
+	baseConverter
 	value *string
 	err   error
 }
@@ -130,6 +135,11 @@ func (c *StringPtrConverter) Result() (*string, error) {
 
 // Value returns the conversion result.
 func (c *StringPtrConverter) Value() *string {
+	return c.value
+}
+
+// Interface returns the conversion result of interface type.
+func (c *StringPtrConverter) Interface() interface{} {
 	return c.value
 }
 

--- a/string.go
+++ b/string.go
@@ -12,7 +12,7 @@ func (c *ValueConverter) String() *StringConverter {
 		err   error
 	)
 
-	inV := reflect.Indirect(reflect.ValueOf(c.value))
+	inV := reflect.Indirect(c.reflectValue)
 	if inV.IsValid() {
 		inT := inV.Type()
 		outT := reflect.TypeOf(value)

--- a/string.go
+++ b/string.go
@@ -59,7 +59,7 @@ func (c *ValueConverter) StringPtr() *StringPtrConverter {
 
 // StringConverter is a converter that converts a string type to another type.
 type StringConverter struct {
-	baseConverter
+	*baseConverter
 	value string
 	err   error
 }
@@ -123,7 +123,7 @@ func (c *StringConverter) Error() error {
 
 // StringPtrConverter is a converter that converts a pointer of string type to another type.
 type StringPtrConverter struct {
-	baseConverter
+	*baseConverter
 	value *string
 	err   error
 }

--- a/struct.go
+++ b/struct.go
@@ -12,7 +12,7 @@ func (c *ValueConverter) Struct() *StructConverter {
 		err   error
 	)
 
-	inV := reflect.Indirect(reflect.ValueOf(c.value))
+	inV := reflect.Indirect(c.reflectValue)
 	switch inV.Kind() {
 	case reflect.Struct:
 		value = c.value

--- a/struct.go
+++ b/struct.go
@@ -5,6 +5,19 @@ import (
 	"reflect"
 )
 
+type (
+	// StructConverter is a converter that converts a struct type to another type.
+	StructConverter struct {
+		*baseConverter
+		value interface{}
+		err   error
+	}
+)
+
+// --------------------------------------------------------------------- //
+// ValueConverter
+// --------------------------------------------------------------------- //
+
 // Struct converts the input to struct type.
 func (c *ValueConverter) Struct() *StructConverter {
 	var (
@@ -26,12 +39,9 @@ func (c *ValueConverter) Struct() *StructConverter {
 	return &StructConverter{baseConverter: c.baseConverter, value: value, err: err}
 }
 
-// StructConverter is a converter that converts a struct type to another type.
-type StructConverter struct {
-	*baseConverter
-	value interface{}
-	err   error
-}
+// --------------------------------------------------------------------- //
+// StructConverter
+// --------------------------------------------------------------------- //
 
 // Convert converts the input to the out type and assigns it.
 // If the conversion fails, the method returns an error.

--- a/struct.go
+++ b/struct.go
@@ -140,7 +140,7 @@ func (c *StructConverter) convert(outV reflect.Value) error {
 			}
 		}
 	default:
-		err = c.new(c.value, c.field).convert(outV)
+		err = c.new(c.value, c.field).Map().convert(outV)
 	}
 
 	if afterCallback, ok := elemOutV.Addr().Interface().(AfterCallback); ok {

--- a/struct.go
+++ b/struct.go
@@ -28,7 +28,7 @@ func (c *ValueConverter) Struct() *StructConverter {
 
 // StructConverter is a converter that converts a struct type to another type.
 type StructConverter struct {
-	baseConverter
+	*baseConverter
 	value interface{}
 	err   error
 }
@@ -65,7 +65,7 @@ func (c *StructConverter) convert(outV reflect.Value) error {
 	elemOutV := toInitializedNonPtrValue(outV)
 
 	if beforeCallback, ok := elemOutV.Addr().Interface().(BeforeCallback); ok {
-		if err = beforeCallback.BeforeConvert(c.value, &c.baseConverter); err != nil {
+		if err = beforeCallback.BeforeConvert(c.value, c.baseConverter); err != nil {
 			goto failed
 		}
 	}
@@ -144,7 +144,7 @@ func (c *StructConverter) convert(outV reflect.Value) error {
 	}
 
 	if afterCallback, ok := elemOutV.Addr().Interface().(AfterCallback); ok {
-		err = afterCallback.AfterConvert(c.value, &c.baseConverter)
+		err = afterCallback.AfterConvert(c.value, c.baseConverter)
 	}
 
 failed:

--- a/syntax_sugar.go
+++ b/syntax_sugar.go
@@ -1,51 +1,51 @@
 package henge
 
 // ToString is equiv to New(i, fs...).String().Value()
-func ToString(i interface{}, fs ...func(*ConverterOpts)) string {
+func ToString(i interface{}, fs ...ConverterOption) string {
 	return New(i, fs...).String().Value()
 }
 
 // ToInt is equiv to New(i, fs...).Int().Value()
-func ToInt(i interface{}, fs ...func(*ConverterOpts)) int64 {
+func ToInt(i interface{}, fs ...ConverterOption) int64 {
 	return New(i, fs...).Int().Value()
 }
 
 // ToUint is equiv to New(i, fs...).Uint().Value()
-func ToUint(i interface{}, fs ...func(*ConverterOpts)) uint64 {
+func ToUint(i interface{}, fs ...ConverterOption) uint64 {
 	return New(i, fs...).Uint().Value()
 }
 
 // ToFloat is equiv to New(i, fs...).Float().Value()
-func ToFloat(i interface{}, fs ...func(*ConverterOpts)) float64 {
+func ToFloat(i interface{}, fs ...ConverterOption) float64 {
 	return New(i, fs...).Float().Value()
 }
 
 // ToBool is equiv to New(i, fs...).Bool().Value()
-func ToBool(i interface{}, fs ...func(*ConverterOpts)) bool {
+func ToBool(i interface{}, fs ...ConverterOption) bool {
 	return New(i, fs...).Bool().Value()
 }
 
 // ToStringPtr is equiv to New(i, fs...).StringPtr().Value()
-func ToStringPtr(i interface{}, fs ...func(*ConverterOpts)) *string {
+func ToStringPtr(i interface{}, fs ...ConverterOption) *string {
 	return New(i, fs...).StringPtr().Value()
 }
 
 // ToIntPtr is equiv to New(i, fs...).IntPtr().Value()
-func ToIntPtr(i interface{}, fs ...func(*ConverterOpts)) *int64 {
+func ToIntPtr(i interface{}, fs ...ConverterOption) *int64 {
 	return New(i, fs...).IntPtr().Value()
 }
 
 // ToUintPtr is equiv to New(i, fs...).UintPtr().Value()
-func ToUintPtr(i interface{}, fs ...func(*ConverterOpts)) *uint64 {
+func ToUintPtr(i interface{}, fs ...ConverterOption) *uint64 {
 	return New(i, fs...).UintPtr().Value()
 }
 
 // ToFloatPtr is equiv to New(i, fs...).FloatPtr().Value()
-func ToFloatPtr(i interface{}, fs ...func(*ConverterOpts)) *float64 {
+func ToFloatPtr(i interface{}, fs ...ConverterOption) *float64 {
 	return New(i, fs...).FloatPtr().Value()
 }
 
 // ToBoolPtr is equiv to New(i, fs...).BoolPtr().Value()
-func ToBoolPtr(i interface{}, fs ...func(*ConverterOpts)) *bool {
+func ToBoolPtr(i interface{}, fs ...ConverterOption) *bool {
 	return New(i, fs...).BoolPtr().Value()
 }

--- a/tests/bool_test.go
+++ b/tests/bool_test.go
@@ -7,6 +7,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestBoolConverter(t *testing.T) {
+	var _ henge.Converter = henge.New(nil).Bool()
+}
+
 func TestBoolConverter_Ptr(t *testing.T) {
 	ptr, err := henge.New(nil).Bool().Ptr().Result()
 	assert.Nil(t, ptr)

--- a/tests/bool_test.go
+++ b/tests/bool_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestBoolConverter(t *testing.T) {
+func TestBoolConverter_interface(t *testing.T) {
 	var _ henge.Converter = henge.New(nil).Bool()
 }
 
@@ -30,4 +30,8 @@ func TestBoolConverter_Ptr(t *testing.T) {
 	ptr, err = henge.New((*struct{})(nil)).Bool().Ptr().Result()
 	assert.Nil(t, ptr)
 	assert.NoError(t, err)
+}
+
+func TestBoolPtrConverter_interface(t *testing.T) {
+	var _ henge.Converter = henge.New(nil).BoolPtr()
 }

--- a/tests/bool_test.go
+++ b/tests/bool_test.go
@@ -3,7 +3,7 @@ package tests
 import (
 	"testing"
 
-	"github.com/soranoba/henge"
+	"github.com/soranoba/henge/v2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/tests/float_test.go
+++ b/tests/float_test.go
@@ -7,6 +7,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestFloatConverter(t *testing.T) {
+	var _ henge.Converter = henge.New(nil).Float()
+}
+
 func TestFloatConverter_Ptr(t *testing.T) {
 	ptr, err := henge.New(struct{}{}).Float().Ptr().Result()
 	assert.Nil(t, ptr)

--- a/tests/float_test.go
+++ b/tests/float_test.go
@@ -3,7 +3,7 @@ package tests
 import (
 	"testing"
 
-	"github.com/soranoba/henge"
+	"github.com/soranoba/henge/v2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/tests/float_test.go
+++ b/tests/float_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFloatConverter(t *testing.T) {
+func TestFloatConverter_interface(t *testing.T) {
 	var _ henge.Converter = henge.New(nil).Float()
 }
 
@@ -30,4 +30,8 @@ func TestFloatConverter_Ptr(t *testing.T) {
 	ptr, err = henge.New((*struct{})(nil)).Float().Ptr().Result()
 	assert.Nil(t, ptr)
 	assert.EqualError(t, err, "Failed to convert from *struct {} to float64: fields=, value=(*struct {})(nil), error=unsupported type")
+}
+
+func TestFloatPtrConverter_interface(t *testing.T) {
+	var _ henge.Converter = henge.New(nil).FloatPtr()
 }

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/soranoba/henge v0.4.2
-	github.com/stretchr/testify v1.6.1
+	github.com/stretchr/testify v1.7.0
 )
 
 replace github.com/soranoba/henge => ../

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -3,8 +3,8 @@ module github.com/soranoba/henge/tests
 go 1.15
 
 require (
-	github.com/soranoba/henge v0.4.2
+	github.com/soranoba/henge/v2 v2.0.0
 	github.com/stretchr/testify v1.7.0
 )
 
-replace github.com/soranoba/henge => ../
+replace github.com/soranoba/henge/v2 => ../

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -2,12 +2,11 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/soranoba/henge v0.4.2 h1:fFNZKFTbnpco1u7SZVKhkNLcznGnZvXLh7xZSI+4dbw=
-github.com/soranoba/henge v0.4.2/go.mod h1:ciz2aYYxiodnIqqbOD0DrIDCk7NXEa3cC7o0Jwh4GHc=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
-github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/tests/henge_test.go
+++ b/tests/henge_test.go
@@ -19,6 +19,10 @@ func TestConverter_Get(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestValueConverter_interface(t *testing.T) {
+	var _ henge.Converter = henge.New(nil)
+}
+
 func TestValueConverter_Convert_Interface(t *testing.T) {
 	var i interface{}
 	assert.NoError(t, henge.New("a").Convert(&i))

--- a/tests/henge_test.go
+++ b/tests/henge_test.go
@@ -7,15 +7,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestConverter_InstanceGet(t *testing.T) {
+func TestConverter_Get(t *testing.T) {
 	c := henge.New("some value")
 
-	c.InstanceSet("key", 1)
-	if v, ok := c.InstanceGet("key").(int); ok {
+	c.Set("key", 1)
+	if v, ok := c.Get("key").(int); ok {
 		assert.Equal(t, 1, v)
 	}
 
-	_, ok := c.InstanceGet("no").(bool)
+	_, ok := c.Get("no").(bool)
 	assert.False(t, ok)
 }
 
@@ -35,6 +35,7 @@ func TestValueConverter_Convert_MapToStruct(t *testing.T) {
 	assert.Equal(t, "a", out.A)
 	assert.Equal(t, "b", out.B)
 }
+
 func TestValueConverter_Model(t *testing.T) {
 	type In struct {
 		X string

--- a/tests/henge_test.go
+++ b/tests/henge_test.go
@@ -7,29 +7,29 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestConverter_Get(t *testing.T) {
+func TestConverter_InstanceGet(t *testing.T) {
 	c := henge.New("some value")
 
-	c.Set("key", 1)
-	if v, ok := c.Get("key").(int); ok {
+	c.InstanceSet("key", 1)
+	if v, ok := c.InstanceGet("key").(int); ok {
 		assert.Equal(t, 1, v)
 	}
 
-	assert.Nil(t, c.Get("no"))
+	assert.Nil(t, c.InstanceGet("no"))
 }
 
-func TestConverter_SetValues(t *testing.T) {
+func TestConverter_InstanceSetValues(t *testing.T) {
 	c := henge.New("some value")
 
-	c.SetValues(map[string]interface{}{"a": 1, "b": 2})
-	if v, ok := c.Get("a").(int); ok {
+	c.InstanceSetValues(map[string]interface{}{"a": 1, "b": 2})
+	if v, ok := c.InstanceGet("a").(int); ok {
 		assert.Equal(t, 1, v)
 	}
-	if v, ok := c.Get("b").(int); ok {
+	if v, ok := c.InstanceGet("b").(int); ok {
 		assert.Equal(t, 2, v)
 	}
 
-	assert.Nil(t, c.Get("c"))
+	assert.Nil(t, c.InstanceGet("c"))
 }
 
 func TestValueConverter_interface(t *testing.T) {

--- a/tests/henge_test.go
+++ b/tests/henge_test.go
@@ -15,12 +15,34 @@ func TestConverter_Get(t *testing.T) {
 		assert.Equal(t, 1, v)
 	}
 
-	_, ok := c.Get("no").(bool)
-	assert.False(t, ok)
+	assert.Nil(t, c.Get("no"))
+}
+
+func TestConverter_SetValues(t *testing.T) {
+	c := henge.New("some value")
+
+	c.SetValues(map[string]interface{}{"a": 1, "b": 2})
+	if v, ok := c.Get("a").(int); ok {
+		assert.Equal(t, 1, v)
+	}
+	if v, ok := c.Get("b").(int); ok {
+		assert.Equal(t, 2, v)
+	}
+
+	assert.Nil(t, c.Get("c"))
 }
 
 func TestValueConverter_interface(t *testing.T) {
 	var _ henge.Converter = henge.New(nil)
+}
+
+func TestValueConverter_Value(t *testing.T) {
+	assert.Equal(t, nil, henge.New(nil).Value())
+	assert.Equal(t, (*string)(nil), henge.New((*string)(nil)).Value())
+	assert.Equal(t, 1, henge.New(1).Value())
+
+	var i int
+	assert.Equal(t, &i, henge.New(&i).Value())
 }
 
 func TestValueConverter_Convert_Interface(t *testing.T) {

--- a/tests/henge_test.go
+++ b/tests/henge_test.go
@@ -3,7 +3,7 @@ package tests
 import (
 	"testing"
 
-	"github.com/soranoba/henge"
+	"github.com/soranoba/henge/v2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/tests/int_test.go
+++ b/tests/int_test.go
@@ -7,7 +7,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestIntegerConverterPtr(t *testing.T) {
+func TestIntegerConverter_interface(t *testing.T) {
+	var _ henge.Converter = henge.New(nil).Int()
+}
+
+func TestIntegerConverter_Ptr(t *testing.T) {
 	ptr, err := henge.New(struct{}{}).Int().Ptr().Result()
 	assert.Nil(t, ptr)
 	assert.EqualError(t, err, "Failed to convert from struct {} to int64: fields=, value=struct {}{}, error=unsupported type")
@@ -26,4 +30,8 @@ func TestIntegerConverterPtr(t *testing.T) {
 	ptr, err = henge.New((*struct{})(nil)).Int().Ptr().Result()
 	assert.Nil(t, ptr)
 	assert.EqualError(t, err, "Failed to convert from *struct {} to int64: fields=, value=(*struct {})(nil), error=unsupported type")
+}
+
+func TestIntegerPtrConverter_interface(t *testing.T) {
+	var _ henge.Converter = henge.New(nil).IntPtr()
 }

--- a/tests/int_test.go
+++ b/tests/int_test.go
@@ -3,7 +3,7 @@ package tests
 import (
 	"testing"
 
-	"github.com/soranoba/henge"
+	"github.com/soranoba/henge/v2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/tests/json_test.go
+++ b/tests/json_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"github.com/soranoba/henge"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -15,4 +16,10 @@ func TestJSONArrayConverter_interface(t *testing.T) {
 
 func TestJSONObjectConverter_interface(t *testing.T) {
 	var _ henge.Converter = henge.New(nil).JSONObject()
+}
+
+func TestJSONValueConverter_nil(t *testing.T) {
+	val, err := henge.New(nil).JSONValue().Result()
+	assert.Nil(t, val)
+	assert.NoError(t, err)
 }

--- a/tests/json_test.go
+++ b/tests/json_test.go
@@ -1,7 +1,7 @@
 package tests
 
 import (
-	"github.com/soranoba/henge"
+	"github.com/soranoba/henge/v2"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )

--- a/tests/json_test.go
+++ b/tests/json_test.go
@@ -1,0 +1,18 @@
+package tests
+
+import (
+	"github.com/soranoba/henge"
+	"testing"
+)
+
+func TestJSONValueConverter_interface(t *testing.T) {
+	var _ henge.Converter = henge.New(nil).JSONValue()
+}
+
+func TestJSONArrayConverter_interface(t *testing.T) {
+	var _ henge.Converter = henge.New(nil).JSONArray()
+}
+
+func TestJSONObjectConverter_interface(t *testing.T) {
+	var _ henge.Converter = henge.New(nil).JSONObject()
+}

--- a/tests/map_test.go
+++ b/tests/map_test.go
@@ -14,14 +14,14 @@ func TestMapConverter_interface(t *testing.T) {
 	var _ henge.Converter = henge.New(nil).Map()
 }
 
-func TestMapConverter_PrivateField(t *testing.T) {
+func TestMapConverter_privateField(t *testing.T) {
 	// NOTE: private fields cannot be copied
 	m, err := henge.New(time.Now()).Map().Result()
 	assert.NoError(t, err)
 	assert.Equal(t, map[interface{}]interface{}{}, m)
 }
 
-func TestMapConverter_Nil(t *testing.T) {
+func TestMapConverter_nil(t *testing.T) {
 	m, err := henge.New((*struct{})(nil)).Map().Result()
 	assert.NoError(t, err)
 	assert.Nil(t, m)
@@ -33,6 +33,19 @@ func TestMapConverter_Nil(t *testing.T) {
 	m, err = henge.New((*int)(nil)).Map().Result()
 	assert.EqualError(t, err, "Failed to convert from *int to map[interface {}]interface {}: fields=, value=(*int)(nil), error=unsupported type")
 	assert.Nil(t, m)
+}
+
+func TestMapConverter_Convert_type(t *testing.T) {
+	src := map[string]interface{}{
+		"a": map[string]interface{}{"a.1": "a.1"},
+		"b": map[string]interface{}{"b.1": "b.1"},
+	}
+	var dst map[string]interface{}
+	assert.NoError(t, henge.New(src).Map().Convert(&dst))
+	assert.NotEqual(t, dst, src)
+
+	assert.NoError(t, henge.New(src, henge.WithMapMaxDepth(0)).Map().Convert(&dst))
+	assert.Equal(t, dst, src)
 }
 
 func TestMapConverter_ConvertPtr(t *testing.T) {

--- a/tests/map_test.go
+++ b/tests/map_test.go
@@ -10,6 +10,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestMapConverter_interface(t *testing.T) {
+	var _ henge.Converter = henge.New(nil).Map()
+}
+
+func TestJSONMapConverter_interface(t *testing.T) {
+	var _ henge.Converter = henge.New(nil).JSONMap()
+}
+
 func TestJSONMapConverter(t *testing.T) {
 	type Internal struct {
 		Y int

--- a/tests/map_test.go
+++ b/tests/map_test.go
@@ -14,27 +14,6 @@ func TestMapConverter_interface(t *testing.T) {
 	var _ henge.Converter = henge.New(nil).Map()
 }
 
-func TestJSONMapConverter_interface(t *testing.T) {
-	var _ henge.Converter = henge.New(nil).JSONMap()
-}
-
-func TestJSONMapConverter(t *testing.T) {
-	type Internal struct {
-		Y int
-		Z string
-	}
-	type In struct {
-		X string
-		I Internal
-	}
-	m, err := henge.New(In{X: "x", I: Internal{Y: 1, Z: "z"}}).JSONMap().Result()
-	assert.NoError(t, err)
-	assert.Equal(t,
-		map[string]interface{}{"X": "x", "I": map[string]interface{}{"Y": 1, "Z": "z"}},
-		m,
-	)
-}
-
 func TestMapConverter_PrivateField(t *testing.T) {
 	// NOTE: private fields cannot be copied
 	m, err := henge.New(time.Now()).Map().Result()

--- a/tests/map_test.go
+++ b/tests/map_test.go
@@ -37,8 +37,11 @@ func TestMapConverter_nil(t *testing.T) {
 
 func TestMapConverter_Convert_type(t *testing.T) {
 	src := map[string]interface{}{
-		"a": map[string]interface{}{"a.1": "a.1"},
-		"b": map[string]interface{}{"b.1": "b.1"},
+		"a": map[string]interface{}{
+			"a.1": map[string]string{
+				"a.1.1": "a.1.1",
+			},
+		},
 	}
 	var dst map[string]interface{}
 	assert.NoError(t, henge.New(src).Map().Convert(&dst))

--- a/tests/map_test.go
+++ b/tests/map_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/soranoba/henge"
+	"github.com/soranoba/henge/v2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/tests/options_test.go
+++ b/tests/options_test.go
@@ -6,14 +6,22 @@ import (
 	"testing"
 )
 
+func TestWithSliceValueConverter_conversionFailed(t *testing.T) {
+	in := []string{"1.5", "2", "2.5", "a"}
+
+	assert.Error(t, henge.New(in, henge.WithSliceValueConverter(func(converter *henge.ValueConverter) henge.Converter {
+		return converter.Float().Int()
+	})).Slice().Error())
+}
+
 func TestWithMapKeyConverter_conversionFailed(t *testing.T) {
 	in := map[interface{}]interface{}{
 		"1.0": map[float64]interface{}{1.5: "a"},
 		"b": map[uint64]interface{}{2: "b"},
 	}
 
-	assert.Error(t, henge.New(in, henge.WithMapKeyConverter(func(keyConverter *henge.ValueConverter) henge.Converter {
-			return keyConverter.Float().Int()
+	assert.Error(t, henge.New(in, henge.WithMapKeyConverter(func(converter *henge.ValueConverter) henge.Converter {
+			return converter.Float().Int()
 	})).Map().Error())
 }
 
@@ -22,15 +30,15 @@ func TestWithValueKeyConverter_conversionFailed(t *testing.T) {
 		"a": map[interface{}]interface{}{"a.1": "a", "a.2": "b"},
 		"b": map[interface{}]interface{}{"b.1": 2.5, "b.2": 2},
 	}
-	assert.Error(t, henge.New(in, henge.WithMapValueConverter(func(key interface{}, valueConverter *henge.ValueConverter) henge.Converter {
-		return valueConverter.Float().Int()
+	assert.Error(t, henge.New(in, henge.WithMapValueConverter(func(converter *henge.ValueConverter) henge.Converter {
+		return converter.Float().Int()
 	})).Map().Error())
 
 	in = map[interface{}]interface{}{
 		"b": map[interface{}]interface{}{"b.1": 2.5, "b.2": 2},
 		"c": struct { X string }{X: "a"},
 	}
-	assert.Error(t, henge.New(in, henge.WithMapValueConverter(func(key interface{}, valueConverter *henge.ValueConverter) henge.Converter {
-		return valueConverter.Float().Int()
+	assert.Error(t, henge.New(in, henge.WithMapValueConverter(func(converter *henge.ValueConverter) henge.Converter {
+		return converter.Float().Int()
 	})).Map().Error())
 }

--- a/tests/options_test.go
+++ b/tests/options_test.go
@@ -1,7 +1,7 @@
 package tests
 
 import (
-	"github.com/soranoba/henge"
+	"github.com/soranoba/henge/v2"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )

--- a/tests/options_test.go
+++ b/tests/options_test.go
@@ -1,0 +1,36 @@
+package tests
+
+import (
+	"github.com/soranoba/henge"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestWithMapKeyConverter_conversionFailed(t *testing.T) {
+	in := map[interface{}]interface{}{
+		"1.0": map[float64]interface{}{1.5: "a"},
+		"b": map[uint64]interface{}{2: "b"},
+	}
+
+	assert.Error(t, henge.New(in, henge.WithMapKeyConverter(func(keyConverter *henge.ValueConverter) henge.Converter {
+			return keyConverter.Float().Int()
+	})).Map().Error())
+}
+
+func TestWithValueKeyConverter_conversionFailed(t *testing.T) {
+	in := map[interface{}]interface{}{
+		"a": map[interface{}]interface{}{"a.1": "a", "a.2": "b"},
+		"b": map[interface{}]interface{}{"b.1": 2.5, "b.2": 2},
+	}
+	assert.Error(t, henge.New(in, henge.WithMapValueConverter(func(key interface{}, valueConverter *henge.ValueConverter) henge.Converter {
+		return valueConverter.Float().Int()
+	})).Map().Error())
+
+	in = map[interface{}]interface{}{
+		"b": map[interface{}]interface{}{"b.1": 2.5, "b.2": 2},
+		"c": struct { X string }{X: "a"},
+	}
+	assert.Error(t, henge.New(in, henge.WithMapValueConverter(func(key interface{}, valueConverter *henge.ValueConverter) henge.Converter {
+		return valueConverter.Float().Int()
+	})).Map().Error())
+}

--- a/tests/options_test.go
+++ b/tests/options_test.go
@@ -17,11 +17,11 @@ func TestWithSliceValueConverter_conversionFailed(t *testing.T) {
 func TestWithMapKeyConverter_conversionFailed(t *testing.T) {
 	in := map[interface{}]interface{}{
 		"1.0": map[float64]interface{}{1.5: "a"},
-		"b": map[uint64]interface{}{2: "b"},
+		"b":   map[uint64]interface{}{2: "b"},
 	}
 
 	assert.Error(t, henge.New(in, henge.WithMapKeyConverter(func(converter *henge.ValueConverter) henge.Converter {
-			return converter.Float().Int()
+		return converter.Float().Int()
 	})).Map().Error())
 }
 
@@ -36,7 +36,7 @@ func TestWithValueKeyConverter_conversionFailed(t *testing.T) {
 
 	in = map[interface{}]interface{}{
 		"b": map[interface{}]interface{}{"b.1": 2.5, "b.2": 2},
-		"c": struct { X string }{X: "a"},
+		"c": struct{ X string }{X: "a"},
 	}
 	assert.Error(t, henge.New(in, henge.WithMapValueConverter(func(converter *henge.ValueConverter) henge.Converter {
 		return converter.Float().Int()

--- a/tests/options_test.go
+++ b/tests/options_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/soranoba/henge/v2"
 	"github.com/stretchr/testify/assert"
 	"testing"
+	"time"
 )
 
 func TestWithSliceValueConverter_conversionFailed(t *testing.T) {
@@ -41,4 +42,24 @@ func TestWithValueKeyConverter_conversionFailed(t *testing.T) {
 	assert.Error(t, henge.New(in, henge.WithMapValueConverter(func(converter *henge.ValueConverter) henge.Converter {
 		return converter.Float().Int()
 	})).Map().Error())
+}
+
+func TestWithMapStructValueConverter_withoutMap(t *testing.T) {
+	in := map[interface{}]interface{}{
+		"a": map[interface{}]interface{}{"a.1": "a", "a.2": "b"},
+		"b": map[interface{}]interface{}{"b.1": 2.5, "b.2": 2},
+		"c": map[interface{}]interface{}{"c.1": time.Now()},
+	}
+
+	assert.Equal(
+		t,
+		map[interface{}]interface{}{
+			"a": map[interface{}]interface{}{"a.1": "a", "a.2": "b"},
+			"b": map[interface{}]interface{}{"b.1": 2.5, "b.2": 2},
+			"c": map[interface{}]interface{}{"c.1": nil},
+		},
+		henge.New(in, henge.WithMapStructValueConverter(func(value interface{}) (out interface{}, ok bool) {
+			return nil, true
+		})).Map().Value(),
+	)
 }

--- a/tests/slice_test.go
+++ b/tests/slice_test.go
@@ -7,7 +7,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSliceConverter_Nil(t *testing.T) {
+func TestSliceConverter_interface(t *testing.T) {
+	var _ henge.Converter = henge.New(nil).Slice()
+	var _ henge.Converter = henge.New(nil).IntSlice()
+	var _ henge.Converter = henge.New(nil).UintSlice()
+	var _ henge.Converter = henge.New(nil).FloatSlice()
+	var _ henge.Converter = henge.New(nil).StringSlice()
+}
+
+func TestSliceConverter_nil(t *testing.T) {
 	s, err := henge.New(([]int)(nil)).Slice().Result()
 	assert.NoError(t, err)
 	assert.Nil(t, s)
@@ -17,7 +25,7 @@ func TestSliceConverter_Nil(t *testing.T) {
 	assert.Nil(t, s)
 }
 
-func TestSliceConverter_PtrSlice(t *testing.T) {
+func TestSliceConverter_Convert_ptrSlice(t *testing.T) {
 	s := make([]*int, 0)
 	assert.NoError(t, henge.New([]int{1, 2, 3}).Slice().Convert(&s))
 	if assert.Equal(t, 3, len(s)) {
@@ -32,7 +40,7 @@ func TestSliceConverter_PtrSlice(t *testing.T) {
 	assert.Equal(t, 2, *a[1])
 }
 
-func TestSliceConverter_NilValue(t *testing.T) {
+func TestSliceConverter_Convert_nilValue(t *testing.T) {
 	s := make([]*int, 0)
 	assert.NoError(t, henge.New(make([]*uint, 3)).Slice().Convert(&s))
 	if assert.Equal(t, 3, len(s)) {

--- a/tests/slice_test.go
+++ b/tests/slice_test.go
@@ -3,7 +3,7 @@ package tests
 import (
 	"testing"
 
-	"github.com/soranoba/henge"
+	"github.com/soranoba/henge/v2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/tests/string_test.go
+++ b/tests/string_test.go
@@ -3,7 +3,7 @@ package tests
 import (
 	"testing"
 
-	"github.com/soranoba/henge"
+	"github.com/soranoba/henge/v2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/tests/string_test.go
+++ b/tests/string_test.go
@@ -7,6 +7,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestStringConverter_interface(t *testing.T) {
+	var _ henge.Converter = henge.New(nil).String()
+}
+
 func TestStringConverter_Convert(t *testing.T) {
 	var s string
 	if assert.NoError(t, henge.New(24.0).String().Convert(&s)) {
@@ -38,4 +42,8 @@ func TestStringConverter_Ptr(t *testing.T) {
 	ptr, err = henge.New((*struct{})(nil)).String().Ptr().Result()
 	assert.Nil(t, ptr)
 	assert.EqualError(t, err, "Failed to convert from *struct {} to string: fields=, value=(*struct {})(nil), error=unsupported type")
+}
+
+func TestStringPtrConverter_interface(t *testing.T) {
+	var _ henge.Converter = henge.New(nil).StringPtr()
 }

--- a/tests/struct_test.go
+++ b/tests/struct_test.go
@@ -216,7 +216,7 @@ type AfterCallbackT struct {
 
 func (t *AfterCallbackT) AfterConvert(src interface{}, store henge.InstanceStore) error {
 	if u, ok := src.(User); ok {
-		diff, _ := store.Get("diff").(int)
+		diff, _ := store.InstanceGet("diff").(int)
 		t.Age = u.Age + diff
 		return nil
 	}
@@ -255,7 +255,7 @@ func TestStructConverter_Callbacks(t *testing.T) {
 	// NOTE: AfterCallbackT converts only from User{} and returns an error otherwise.
 	out2 := AfterCallbackT{}
 	conv := henge.New(user)
-	conv.Set("diff", 23)
+	conv.InstanceSet("diff", 23)
 	assert.NoError(t, conv.Struct().Convert(&out2))
 	assert.Equal(t, user.Name, out2.Name)
 	assert.Equal(t, 48, out2.Age)

--- a/tests/struct_test.go
+++ b/tests/struct_test.go
@@ -15,6 +15,10 @@ type User struct {
 	Age  int
 }
 
+func TestStructConverter_interface(t *testing.T) {
+	var _ henge.Converter = henge.New(nil).Struct()
+}
+
 func TestStructConverter_EmbeddedField(t *testing.T) {
 	type In struct {
 		A string

--- a/tests/struct_test.go
+++ b/tests/struct_test.go
@@ -194,11 +194,15 @@ type BeforeCallbackT struct {
 	Age  int
 }
 
-func (t *BeforeCallbackT) BeforeConvert(src interface{}, converter henge.Converter) error {
+func (t *BeforeCallbackT) BeforeConvert(src interface{}, store henge.InstanceStore) error {
 	if _, ok := src.(User); ok {
 		return nil
 	}
 	return errors.New("failed")
+}
+
+func TestBeforeCallbackT(t *testing.T) {
+	var _ henge.BeforeCallback = &BeforeCallbackT{}
 }
 
 type AfterCallbackT struct {
@@ -206,13 +210,17 @@ type AfterCallbackT struct {
 	Age  int
 }
 
-func (t *AfterCallbackT) AfterConvert(src interface{}, converter henge.Converter) error {
+func (t *AfterCallbackT) AfterConvert(src interface{}, store henge.InstanceStore) error {
 	if u, ok := src.(User); ok {
-		diff, _ := converter.InstanceGet("diff").(int)
+		diff, _ := store.Get("diff").(int)
 		t.Age = u.Age + diff
 		return nil
 	}
 	return errors.New("failed")
+}
+
+func TestAfterCallbackT(t *testing.T) {
+	var _ henge.AfterCallback = &AfterCallbackT{}
 }
 
 func TestStructConverter_Callbacks(t *testing.T) {
@@ -243,7 +251,7 @@ func TestStructConverter_Callbacks(t *testing.T) {
 	// NOTE: AfterCallbackT converts only from User{} and returns an error otherwise.
 	out2 := AfterCallbackT{}
 	conv := henge.New(user)
-	conv.InstanceSet("diff", 23)
+	conv.Set("diff", 23)
 	assert.NoError(t, conv.Struct().Convert(&out2))
 	assert.Equal(t, user.Name, out2.Name)
 	assert.Equal(t, 48, out2.Age)

--- a/tests/struct_test.go
+++ b/tests/struct_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/soranoba/henge"
+	"github.com/soranoba/henge/v2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/tests/struct_test.go
+++ b/tests/struct_test.go
@@ -19,6 +19,34 @@ func TestStructConverter_interface(t *testing.T) {
 	var _ henge.Converter = henge.New(nil).Struct()
 }
 
+func TestStructConverter_Convert_map(t *testing.T) {
+	type T1 struct {
+		X       int
+		Payload map[string]interface{}
+	}
+	type T2 struct {
+		X       string
+		Payload map[string]interface{}
+	}
+
+	in := T1{
+		Payload: map[string]interface{}{
+			"a": map[string]interface{}{
+				"a.1": map[string]string{
+					"a.1.1": "a.1.1",
+				},
+			},
+		},
+	}
+	var out T2
+
+	assert.NoError(t, henge.New(in).Struct().Convert(&out))
+	assert.NotEqual(t, out.Payload, in.Payload)
+
+	assert.NoError(t, henge.New(in, henge.WithMapMaxDepth(0)).Map().Convert(&out))
+	assert.Equal(t, out.Payload, in.Payload)
+}
+
 func TestStructConverter_EmbeddedField(t *testing.T) {
 	type In struct {
 		A string

--- a/tests/uint_test.go
+++ b/tests/uint_test.go
@@ -3,7 +3,7 @@ package tests
 import (
 	"testing"
 
-	"github.com/soranoba/henge"
+	"github.com/soranoba/henge/v2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/tests/uint_test.go
+++ b/tests/uint_test.go
@@ -7,6 +7,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestUnsignedIntegerConverter_interface(t *testing.T) {
+	var _ henge.Converter = henge.New(nil).Uint()
+}
+
 func TestUnsignedIntegerConverter_Convert(t *testing.T) {
 	var s string
 	if assert.NoError(t, henge.New(24.0).Uint().Convert(&s)) {
@@ -38,4 +42,8 @@ func TestUnsignedIntegerConverter_Ptr(t *testing.T) {
 	ptr, err = henge.New((*struct{})(nil)).Uint().Ptr().Result()
 	assert.Nil(t, ptr)
 	assert.EqualError(t, err, "Failed to convert from *struct {} to uint64: fields=, value=(*struct {})(nil), error=unsupported type")
+}
+
+func TestUnsignedIntegerPtrConverter_interface(t *testing.T) {
+	var _ henge.Converter = henge.New(nil).UintPtr()
 }

--- a/uint.go
+++ b/uint.go
@@ -6,6 +6,26 @@ import (
 	"strconv"
 )
 
+type (
+	// UnsignedIntegerConverter is a converter that converts an unsigned integer type to another type.
+	UnsignedIntegerConverter struct {
+		*baseConverter
+		value uint64
+		err   error
+	}
+
+	// UnsignedIntegerPtrConverter is a converter that converts a pointer of uint type to another type.
+	UnsignedIntegerPtrConverter struct {
+		*baseConverter
+		value *uint64
+		err   error
+	}
+)
+
+// --------------------------------------------------------------------- //
+// ValueConverter
+// --------------------------------------------------------------------- //
+
 // Uint converts the input to uint type.
 func (c *ValueConverter) Uint() *UnsignedIntegerConverter {
 	var (
@@ -63,12 +83,9 @@ func (c *ValueConverter) UintPtr() *UnsignedIntegerPtrConverter {
 	return c.Uint().Ptr()
 }
 
-// UnsignedIntegerConverter is a converter that converts an unsigned integer type to another type.
-type UnsignedIntegerConverter struct {
-	*baseConverter
-	value uint64
-	err   error
-}
+// --------------------------------------------------------------------- //
+// UnsignedIntegerConverter
+// --------------------------------------------------------------------- //
 
 // Ptr converts the input to ptr type.
 func (c *UnsignedIntegerConverter) Ptr() *UnsignedIntegerPtrConverter {
@@ -148,12 +165,9 @@ func (c *UnsignedIntegerConverter) Error() error {
 	return c.err
 }
 
-// UnsignedIntegerPtrConverter is a converter that converts a pointer of uint type to another type.
-type UnsignedIntegerPtrConverter struct {
-	*baseConverter
-	value *uint64
-	err   error
-}
+// --------------------------------------------------------------------- //
+// UnsignedIntegerPtrConverter
+// --------------------------------------------------------------------- //
 
 // Result returns the conversion result and error.
 func (c *UnsignedIntegerPtrConverter) Result() (*uint64, error) {

--- a/uint.go
+++ b/uint.go
@@ -138,6 +138,11 @@ func (c *UnsignedIntegerConverter) Value() uint64 {
 	return c.value
 }
 
+// Interface returns the conversion result of interface type.
+func (c *UnsignedIntegerConverter) Interface() interface{} {
+	return c.value
+}
+
 // Error returns an error if the conversion fails.
 func (c *UnsignedIntegerConverter) Error() error {
 	return c.err
@@ -157,6 +162,11 @@ func (c *UnsignedIntegerPtrConverter) Result() (*uint64, error) {
 
 // Value returns the conversion result.
 func (c *UnsignedIntegerPtrConverter) Value() *uint64 {
+	return c.value
+}
+
+// Interface returns the conversion result of interface type.
+func (c *UnsignedIntegerPtrConverter) Interface() interface{} {
 	return c.value
 }
 

--- a/uint.go
+++ b/uint.go
@@ -13,7 +13,7 @@ func (c *ValueConverter) Uint() *UnsignedIntegerConverter {
 		err   error
 	)
 
-	inV := reflect.Indirect(reflect.ValueOf(c.value))
+	inV := reflect.Indirect(c.reflectValue)
 	if inV.IsValid() {
 		inT := inV.Type()
 		outT := reflect.TypeOf(value)

--- a/uint.go
+++ b/uint.go
@@ -65,7 +65,7 @@ func (c *ValueConverter) UintPtr() *UnsignedIntegerPtrConverter {
 
 // UnsignedIntegerConverter is a converter that converts an unsigned integer type to another type.
 type UnsignedIntegerConverter struct {
-	baseConverter
+	*baseConverter
 	value uint64
 	err   error
 }
@@ -145,7 +145,7 @@ func (c *UnsignedIntegerConverter) Error() error {
 
 // UnsignedIntegerPtrConverter is a converter that converts a pointer of uint type to another type.
 type UnsignedIntegerPtrConverter struct {
-	baseConverter
+	*baseConverter
 	value *uint64
 	err   error
 }

--- a/uint.go
+++ b/uint.go
@@ -55,7 +55,7 @@ func (c *ValueConverter) Uint() *UnsignedIntegerConverter {
 	if err != nil {
 		err = c.wrapConvertError(c.value, reflect.ValueOf((*uint64)(nil)).Type().Elem(), err)
 	}
-	return &UnsignedIntegerConverter{converter: c.converter, value: value, err: err}
+	return &UnsignedIntegerConverter{baseConverter: c.baseConverter, value: value, err: err}
 }
 
 // UintPtr converts the input to pointer of uint type.
@@ -65,7 +65,7 @@ func (c *ValueConverter) UintPtr() *UnsignedIntegerPtrConverter {
 
 // UnsignedIntegerConverter is a converter that converts an unsigned integer type to another type.
 type UnsignedIntegerConverter struct {
-	converter
+	baseConverter
 	value uint64
 	err   error
 }
@@ -73,9 +73,9 @@ type UnsignedIntegerConverter struct {
 // Ptr converts the input to ptr type.
 func (c *UnsignedIntegerConverter) Ptr() *UnsignedIntegerPtrConverter {
 	if c.err != nil || c.isNil {
-		return &UnsignedIntegerPtrConverter{converter: c.converter, value: nil, err: c.err}
+		return &UnsignedIntegerPtrConverter{baseConverter: c.baseConverter, value: nil, err: c.err}
 	}
-	return &UnsignedIntegerPtrConverter{converter: c.converter, value: &c.value, err: nil}
+	return &UnsignedIntegerPtrConverter{baseConverter: c.baseConverter, value: &c.value, err: nil}
 }
 
 // Convert converts the input to the out type and assigns it.
@@ -145,7 +145,7 @@ func (c *UnsignedIntegerConverter) Error() error {
 
 // UnsignedIntegerPtrConverter is a converter that converts a pointer of uint type to another type.
 type UnsignedIntegerPtrConverter struct {
-	converter
+	baseConverter
 	value *uint64
 	err   error
 }


### PR DESCRIPTION
resolve #3

### Breaking Changes

#### Behavior

```go
src := map[string]interface{}{
	"a": map[string]interface{}{"a.1": "a.1"},
}
var dst map[string]interface{}
henge.New(src).Map().Convert(&dst)
```

v1: Type of `dst["a"]` is `map[string]interface{}`
v2: Type of `dst["b"]` is `map[interface{}]interface{}`

This means that it may be converted to a non-json-marshalable type from json-marshalable type.
You should replace it with the following method if necessary.

```go
henge.New(src).JSONObject().Convert(&dst)
henge.New(src, henge.WithMapMaxDepth(0)).Convert(&dst)
```

#### Interface changes
```diff
type BeforeCallback interface {
-	BeforeConvert(src interface{}, converter Converter) error
+	BeforeConvert(src interface{}, store InstanceStore) error
}

type AfterCallback interface {
-	AfterConvert(src interface{}, converter Converter) error
+	AfterConvert(src interface{}, store InstanceStore) error
}
```

#### Renames

||v1|v2|
|:--|:---|:--|
|type|`func(*ConverterOpts)`|`ConverterOption`|
|interface|`Converter`|`InstanceStore`|
|method|`ValueConverter.JSONMap()`|`ValueConverter.JSONObject()`|
|struct|`JSONMapConverter`|`JSONObjectConverter`|
|method|`ValueConverter. FloatrPtr()`|`ValueConverter.FloatPtr()`|

### New Features

#### New Conversions

- JSONValue
- JSONArray
- JSONObject

#### New Options

- WithSliceValueConverter
- WithMapKeyConverter
- WithMapValueConverter
- WithMapStructValueConverter
- WithMapTimeValueStringConverter

### Bug fixes

- #8 : ValueConverter.Value() returns incorrect value when srcValue is nil.
