### PR TITLE
Callbacks for the new struct conversion: BeforeConvert{To,From}Callback, AfterConvert{To,From}Callback

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -1,11 +1,41 @@
 package henge
 
 // BeforeCallback is a callback that is executed before the conversion from a struct to the struct.
+// Deprecated: Use BeforeConvertFromCallback instead.
 type BeforeCallback interface {
 	BeforeConvert(src interface{}, store InstanceStore) error
 }
 
 // AfterCallback is a callback that is executed after the conversion from a struct to the struct.
+// Deprecated: Use AfterConvertFromCallback instead.
 type AfterCallback interface {
 	AfterConvert(src interface{}, store InstanceStore) error
+}
+
+// BeforeConvertFromCallback is a callback that is executed before the conversion from a struct to the struct.
+// To define structures across packages, you need to define them in the package's struct that imports other packages.
+// Within structures of the same package, you must use BeforeConvertFromCallback. It cannot be used simultaneously with BeforeConvertToCallback.
+type BeforeConvertFromCallback interface {
+	BeforeConvertFrom(src interface{}, store InstanceStore) error
+}
+
+// AfterConvertFromCallback is a callback that is executed after the conversion from a struct to the struct.
+// To define structures across packages, you need to define them in the package's struct that imports other packages.
+// Within structures of the same package, you must use AfterConvertFromCallback. It cannot be used simultaneously with AfterConvertToCallback.
+type AfterConvertFromCallback interface {
+	AfterConvertFrom(src interface{}, store InstanceStore) error
+}
+
+// BeforeConvertToCallback is a callback that is executed before the conversion from the struct to a struct.
+// To define structures across packages, you need to define them in the package's struct that imports other packages.
+// Within structures of the same package, you must use BeforeConvertFromCallback. It cannot be used simultaneously with BeforeConvertToCallback.
+type BeforeConvertToCallback interface {
+	BeforeConvertTo(dst interface{}, store InstanceStore) error
+}
+
+// AfterConvertToCallback is a callback that is executed after the conversion from the struct to a struct.
+// To define structures across packages, you need to define them in the package's struct that imports other packages.
+// Within structures of the same package, you must use AfterConvertFromCallback. It cannot be used simultaneously with AfterConvertToCallback.
+type AfterConvertToCallback interface {
+	AfterConvertTo(dst interface{}, store InstanceStore) error
 }

--- a/struct.go
+++ b/struct.go
@@ -2,7 +2,6 @@ package henge
 
 import (
 	"errors"
-	"log"
 	"reflect"
 )
 
@@ -75,29 +74,20 @@ func (c *StructConverter) convert(outV reflect.Value) error {
 	var err error
 	elemOutV := toInitializedNonPtrValue(outV)
 
-	beforeCallbackCount := 0
-	afterCallbackCount := 0
-
 	if beforeCallback, ok := elemOutV.Addr().Interface().(BeforeCallback); ok {
-		beforeCallbackCount += 1
 		if err = beforeCallback.BeforeConvert(c.value, c.baseConverter); err != nil {
 			goto failed
 		}
 	}
 	if beforeCallback, ok := elemOutV.Addr().Interface().(BeforeConvertFromCallback); ok {
-		beforeCallbackCount += 1
 		if err = beforeCallback.BeforeConvertFrom(c.value, c.baseConverter); err != nil {
 			goto failed
 		}
 	}
 	if beforeCallback, ok := reflect.ValueOf(c.value).Interface().(BeforeConvertToCallback); ok {
-		beforeCallbackCount += 1
 		if err = beforeCallback.BeforeConvertTo(elemOutV.Addr().Interface(), c.baseConverter); err != nil {
 			goto failed
 		}
-	}
-	if beforeCallbackCount > 1 {
-		log.Fatalf("Only one of the following can be defined between the structs: BeforeCallback, BeforeConvertFromCallback, or BeforeConvertToCallback. (%T, %T)", reflect.ValueOf(c.value).Interface(), elemOutV.Addr().Interface())
 	}
 
 	switch elemOutV.Kind() {
@@ -174,25 +164,19 @@ func (c *StructConverter) convert(outV reflect.Value) error {
 	}
 
 	if afterCallback, ok := elemOutV.Addr().Interface().(AfterCallback); ok {
-		afterCallbackCount += 1
 		if err = afterCallback.AfterConvert(c.value, c.baseConverter); err != nil {
 			goto failed
 		}
 	}
 	if afterCallback, ok := elemOutV.Addr().Interface().(AfterConvertFromCallback); ok {
-		afterCallbackCount += 1
 		if err = afterCallback.AfterConvertFrom(c.value, c.baseConverter); err != nil {
 			goto failed
 		}
 	}
 	if afterCallback, ok := reflect.ValueOf(c.value).Interface().(AfterConvertToCallback); ok {
-		afterCallbackCount += 1
 		if err = afterCallback.AfterConvertTo(elemOutV.Addr().Interface(), c.baseConverter); err != nil {
 			goto failed
 		}
-	}
-	if afterCallbackCount > 1 {
-		log.Fatalf("Only one of the following can be defined between the structs: AfterCallback, AfterConvertFromCallback, or AfterConvertToCallback. (%T, %T)", reflect.ValueOf(c.value).Interface(), elemOutV.Addr().Interface())
 	}
 
 failed:

--- a/struct.go
+++ b/struct.go
@@ -2,6 +2,7 @@ package henge
 
 import (
 	"errors"
+	"log"
 	"reflect"
 )
 
@@ -74,10 +75,29 @@ func (c *StructConverter) convert(outV reflect.Value) error {
 	var err error
 	elemOutV := toInitializedNonPtrValue(outV)
 
+	beforeCallbackCount := 0
+	afterCallbackCount := 0
+
 	if beforeCallback, ok := elemOutV.Addr().Interface().(BeforeCallback); ok {
+		beforeCallbackCount += 1
 		if err = beforeCallback.BeforeConvert(c.value, c.baseConverter); err != nil {
 			goto failed
 		}
+	}
+	if beforeCallback, ok := elemOutV.Addr().Interface().(BeforeConvertFromCallback); ok {
+		beforeCallbackCount += 1
+		if err = beforeCallback.BeforeConvertFrom(c.value, c.baseConverter); err != nil {
+			goto failed
+		}
+	}
+	if beforeCallback, ok := reflect.ValueOf(c.value).Interface().(BeforeConvertToCallback); ok {
+		beforeCallbackCount += 1
+		if err = beforeCallback.BeforeConvertTo(elemOutV.Addr().Interface(), c.baseConverter); err != nil {
+			goto failed
+		}
+	}
+	if beforeCallbackCount > 1 {
+		log.Fatalf("Only one of the following can be defined between the structs: BeforeCallback, BeforeConvertFromCallback, or BeforeConvertToCallback. (%T, %T)", reflect.ValueOf(c.value).Interface(), elemOutV.Addr().Interface())
 	}
 
 	switch elemOutV.Kind() {
@@ -154,7 +174,25 @@ func (c *StructConverter) convert(outV reflect.Value) error {
 	}
 
 	if afterCallback, ok := elemOutV.Addr().Interface().(AfterCallback); ok {
-		err = afterCallback.AfterConvert(c.value, c.baseConverter)
+		afterCallbackCount += 1
+		if err = afterCallback.AfterConvert(c.value, c.baseConverter); err != nil {
+			goto failed
+		}
+	}
+	if afterCallback, ok := elemOutV.Addr().Interface().(AfterConvertFromCallback); ok {
+		afterCallbackCount += 1
+		if err = afterCallback.AfterConvertFrom(c.value, c.baseConverter); err != nil {
+			goto failed
+		}
+	}
+	if afterCallback, ok := reflect.ValueOf(c.value).Interface().(AfterConvertToCallback); ok {
+		afterCallbackCount += 1
+		if err = afterCallback.AfterConvertTo(elemOutV.Addr().Interface(), c.baseConverter); err != nil {
+			goto failed
+		}
+	}
+	if afterCallbackCount > 1 {
+		log.Fatalf("Only one of the following can be defined between the structs: AfterCallback, AfterConvertFromCallback, or AfterConvertToCallback. (%T, %T)", reflect.ValueOf(c.value).Interface(), elemOutV.Addr().Interface())
 	}
 
 failed:


### PR DESCRIPTION
When converting structs that across packages, the conventional method only allowed callbacks for one of conversion. This PR resolves that limitation.